### PR TITLE
Part 2 header now shows up

### DIFF
--- a/_posts/2016-08-27-pointers-gone-wild.md
+++ b/_posts/2016-08-27-pointers-gone-wild.md
@@ -84,7 +84,7 @@ Result: 2499
 7
 {% endhighlight %}
 
-##Part 2:
+## Part 2:
 
 We have pre-uploaded some files to your mp0 svn directory, including <tt>part2-functions.c</tt>. Inside <tt>part2-functions.c</tt>, you will see twelve different functions, including <tt>first_step()</tt> (re-printed below).
 


### PR DESCRIPTION
It was missing a space, so it showed up in the GitHub preview but not in the actual website.