### PR TITLE
Submission instructions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@
 # 'jekyll serve'. If you change this file, please restart the server process.
 
 # Site settings
-title: CS 241 - System Programming
+title: "CS 241 - System Programming"
 email: angrave@illinois.edu
 description: > # this means to ignore newlines until "baseurl:"
   Webpage for CS241.
@@ -14,6 +14,10 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "http://illinois-cs241.github.io" # the base hostname & protocol for your site
 repository: illinois-cs241/illinois-cs241.github.io
 github_username: illinois-cs241
+semester: "fa16"
+course_number: "241"
+subject_code: "cs"
+course_name: "System Programming"
 
 # Build settings
 markdown: kramdown

--- a/_drafts/2017-04-24-wearables.md
+++ b/_drafts/2017-04-24-wearables.md
@@ -193,22 +193,3 @@ This portion is ungraded, but you may find it helpful for both checking understa
 * Explain in plain English what sockets are, and how we use them inside Unix programs (hint: think files). How are sockets different from other files you have encountered `so far? (Do they have inode metadata? Do writes on sockets result in Disk I/O?).
 * How are sockets related to ports? Can you think of a way to uniquely identify a connection with sockets? What could be some reasons to allow for the reusing of ports?
 * Does TCP encrypt packets that are sent over the network? If not, what are some ways in which encryption is carried out?
-
-## Grading, Submission, and Other Details
-
-Please fully read details on [Academic Honesty](https://courses.engr.illinois.edu/cs241/#/overview#integrity).
-These are shared between all MPs in CS 241.
-
-To check out the provided code for wearables from the class repository, go to your cs241 directory (the one you checked out for "know your tools") and run:
-
-{% highlight bash %} svn up {% endhighlight %}
-
-If you run ls you will now see a wearables folder, where you can find this assignment! To commit your changes (send them to us) type:
-
-{% highlight bash %} svn ci -m "wearables submission" {% endhighlight %}
-
-Your repository directory can be viewed from a web browser from the following URL: https://subversion.ews.illinois.edu/svn/fa16-cs241/NETID/wearables where NETID is your University NetID.
-
-You will implement the logic for your server in wearable_server.c. This file will be used for grading. 
-
-It is important to check that the files you expect to be graded are present and up to date in your svn copy.

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -36,7 +36,7 @@
 				<h2 id="submission-instructions">Submission Instructions</h2>
 				<p>
 					Please fully read details on
-					<a href="https://courses.engr.illinois.edu/cs241/#/overview#integrity"> Academic Integrity </a>.
+					<a href="{{ site.url }}/#academic-integrity"> Academic Integrity </a>.
 					These are shared between all MPs in CS 241.
 				</p>
 				<p>
@@ -45,20 +45,22 @@
 					Therefore, to hand in your code, all you have to do is commit it to your Subversion repository.
 				</p>
 				<p>
-				To check out the provided code for
-				<code>pointers_gone_wild</code> from the class repository, go to your cs241 directory (the one you checked out for "know your tools") and run:
-					{% highlight console %}$ svn up{% endhighlight %}
+					To check out the provided code for
+					<code>{{ page.permalink }}</code>
+					from the class repository, go to your cs241 directory (the one you checked out for "know your tools") and run:
+					{% highlight text %}svn up{% endhighlight %}
 				</p>
 				<p>
-				If you run <code>ls</code> you will now see a
-				<code>pointers_gone_wild</code> folder, where you can find this assignment! To commit your changes (send them to us) type:
+					If you run <code>ls</code> you will now see a
+					<code>{{ page.permalink }}</code> folder, where you can find this assignment! To commit your changes (send them to us) type:
 
-					{% highlight console %}$ svn ci -m "mp0 submission"{% endhighlight %}
+					{% highlight text %}svn ci -m "{{ page.permalink }} submission"{% endhighlight %}
 				</p>
 				<p>
 					Your repository directory can be viewed from a web browser from the following URL:
-					<a href="https://subversion.ews.illinois.edu/svn/fa16-cs241/NETID/pointers_gone_wild">
-						https://subversion.ews.illinois.edu/svn/fa16-cs241/NETID/pointers_gone_wild
+					<a
+						href="https://subversion.ews.illinois.edu/svn/{{site.semester }}-{{ site.subject_code }}{{ site.course_number }}/NETID/{{ page.permalink }}">
+						https://subversion.ews.illinois.edu/svn/{{site.semester }}-{{ site.subject_code }}{{ site.course_number }}/NETID/{{ page.permalink }}
 					</a>
 					where NETID is your University NetID.
 					It is important to check that the files you expect to be graded are present and up to date in your SVN copy.

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -33,6 +33,7 @@
               <div id="content">
                 {{ content }}
 
+                {% if page.date %}
 				<h2 id="submission-instructions">Submission Instructions</h2>
 				<p>
 					Please fully read details on
@@ -65,6 +66,7 @@
 					where NETID is your University NetID.
 					It is important to check that the files you expect to be graded are present and up to date in your SVN copy.
 				</p>
+                {% endif %}
               </div>
             </div>
           </div>

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -32,6 +32,9 @@
               </nav>
               <div id="content">
                 {{ content }}
+
+				<h2 id="submission-instructions">Submission Instructions</h2>
+				<p>content</p>
               </div>
             </div>
           </div>

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -34,7 +34,35 @@
                 {{ content }}
 
 				<h2 id="submission-instructions">Submission Instructions</h2>
-				<p>content</p>
+				<p>
+					Please fully read details on
+					<a href="https://courses.engr.illinois.edu/cs241/#/overview#integrity"> Academic Integrity </a>.
+					These are shared between all MPs in CS 241.
+				</p>
+				<p>
+					We will be using Subversion as our hand-in system this semester.
+					Our grading system will checkout your most recent (pre-deadline) commit for grading.
+					Therefore, to hand in your code, all you have to do is commit it to your Subversion repository.
+				</p>
+				<p>
+				To check out the provided code for
+				<code>pointers_gone_wild</code> from the class repository, go to your cs241 directory (the one you checked out for "know your tools") and run:
+					{% highlight console %}$ svn up{% endhighlight %}
+				</p>
+				<p>
+				If you run <code>ls</code> you will now see a
+				<code>pointers_gone_wild</code> folder, where you can find this assignment! To commit your changes (send them to us) type:
+
+					{% highlight console %}$ svn ci -m "mp0 submission"{% endhighlight %}
+				</p>
+				<p>
+					Your repository directory can be viewed from a web browser from the following URL:
+					<a href="https://subversion.ews.illinois.edu/svn/fa16-cs241/NETID/pointers_gone_wild">
+						https://subversion.ews.illinois.edu/svn/fa16-cs241/NETID/pointers_gone_wild
+					</a>
+					where NETID is your University NetID.
+					It is important to check that the files you expect to be graded are present and up to date in your SVN copy.
+				</p>
               </div>
             </div>
           </div>

--- a/_posts/2016-08-27-pointers-gone-wild.md
+++ b/_posts/2016-08-27-pointers-gone-wild.md
@@ -156,23 +156,3 @@ or
 {% highlight bash %}
 ./part2-debug
 {% endhighlight %}
-
-## Grading, Submission, and Other Details
-
-Please fully read details on [Academic Honesty](https://courses.engr.illinois.edu/cs241/#/overview#integrity). These are shared between all MPs in CS 241.
-
-We will be using Subversion as our hand-in system this semester. Our grading system will checkout your most recent (pre-deadline) commit for grading. Therefore, to hand in your code, all you have to do is commit it to your Subversion repository.
-
-To check out the provided code for `pointers_gone_wild`from the class repository, go to your cs241 directory (the one you checked out for "know your tools") and run:
-
-{% highlight bash %}
-svn up
-{% endhighlight %}
-
-If you run `ls` you will now see a `pointers_gone_wild` folder, where you can find this assignment! To commit your changes (send them to us) type:
-
-{% highlight bash %}
-svn ci -m "mp0 submission"
-{% endhighlight %}
-
-Your repository directory can be viewed from a web browser from the following URL: [https://subversion.ews.illinois.edu/svn/fa16-cs241/NETID/pointers_gone_wild](https://subversion.ews.illinois.edu/svn/fa16-cs241/NETID/pointers_gone_wild) where NETID is your University NetID. It is important to check that the files you expect to be graded are present and up to date in your SVN copy.

--- a/_posts/2016-09-05-vector.md
+++ b/_posts/2016-09-05-vector.md
@@ -127,25 +127,3 @@ or:
 {% highlight bash %}
 ./document_test-debug
 {% endhighlight %}
-
-
-## Grading, submission, and other details
-
-Please fully read details on [Academic Honesty](https://illinois-cs241.github.io/#academic-integrity). These apply to all assignments in CS 241.
-
-We will be using Subversion as our hand-in system this semester. Our grading system will checkout your most recent (pre-deadline) commit for grading. Therefore, to hand in your code, all you have to do is commit it to your Subversion repository.
-
-To check out the provided code for `vector` from the class repository, go to your cs241 directory (the one you checked out for "know your tools") and run:
-
-{% highlight bash %}
-svn up
-{% endhighlight %}
-
-
-If you run `ls` you will now see a `vector` folder, where you can find this assignment! To commit your changes, type:
-
-{% highlight bash %}
-svn ci -m "vector submission"
-{% endhighlight %}
-
-Your repository directory can be viewed from a web browser from [https://subversion.ews.illinois.edu/svn/fa16-cs241/NETID/vector](https://subversion.ews.illinois.edu/svn/fa16-cs241/NETID/vector), where NETID is your University NetID. It is important to check that the files you expect to be graded are present and up to date in your SVN copy.

--- a/_posts/2016-09-11-text-editor.md
+++ b/_posts/2016-09-11-text-editor.md
@@ -401,43 +401,6 @@ your mentor with a bash script that runs some editor scripts over some files
 you create, then uses the `diff` tool (check the man pages) to make sure your
 editor did the right thing.
 
-## Grading, submission, and other details
-Please fully read details on [Academic
-Honesty](https://courses.engr.illinois.edu/cs241/#/overview#integrity).  These
-are shared by all MPs in CS 241.
-
-We will be using Subversion as our hand-in system this semester. Our grading
-system will checkout your most recent (pre-deadline) commit for grading.
-Therefore, to hand in your code, all you have to do is commit it to your
-Subversion repository.
-
-To check out the provided code for `text_editor` from the class repository,
-go to your cs241 directory (the one you checked out for "know your tools")
-and run:
-
-{% highlight bash %}
-svn up
-{% endhighlight %}
-
-If you run `ls` you will now see a `text_editor` folder, where you can find
-this assignment! To commit your changes (send them to us) type:
-
-{% highlight bash %}
-svn ci -m "mp2 submission"
-{% endhighlight %}
-
-Your repository directory can be viewed from a web browser from the
-following URL:
-[https://subversion.ews.illinois.edu/svn/fa16-cs241/NETID/vector](https://subversion.ews.illinois.edu/svn/fa16-cs241/NETID/vector)
-where NETID is your University NetID. It is important to check that the
-files you expect to be graded are present and up to date in your svn copy.
-
-### Only edit the following files
-
-We will only use the files in this list when running the autograder:
-
-*   `editor.c`
-
 ## Compile and run
 
 Because we have provided `Document` and `Vector` as a precompiled archive

--- a/_posts/2016-09-19-shell.md
+++ b/_posts/2016-09-19-shell.md
@@ -266,27 +266,6 @@ When I type, it shows up on this line
 
 While the shell should be usable after calling the command, after the process finishes the parent is still responsible for waiting on the child (hint: catch a signal). Avoid creating zombies!
 
-## Grading, Submission, and Other Details
-
-Please fully read details on [Academic Honesty](https://courses.engr.illinois.edu/cs241/#/overview#integrity). These are shared between all MPs in CS 241.
-
-We will be using Subversion as our hand-in system this semester. Our grading system will checkout your most recent (pre-deadline) commit for grading. Therefore, to hand in your code, all you have to do is commit it to your Subversion repository.
-
-To check out the provided code for `shell` from the class repository, go to your cs241 directory (the one you checked out for "know your tools") and run:
-
-{% highlight bash %}
-svn up
-{% endhighlight %}
-
-
-If you run `ls` you will now see a `shell` folder, where you can find this assignment! To commit your changes (send them to us) type:
-
-{% highlight bash %}
-svn ci -m "shell submission"
-{% endhighlight %}
-
-Your repository directory can be viewed from a web browser from the following URL: [https://subversion.ews.illinois.edu/svn/fa16-cs241/NETID/shell](https://subversion.ews.illinois.edu/svn/fa16-cs241/NETID/shell) where NETID is your University NetID. It is important to check that the files you expect to be graded are present and up to date in your svn copy.
-
 ## Compile and Run
 
 Because we have provided `Log` and `Vector` as precompiled archive

--- a/_posts/2016-09-26-malloc.md
+++ b/_posts/2016-09-26-malloc.md
@@ -111,11 +111,7 @@ The malloc contest pits your implementations of memory allocating functions agai
 
 **WARNING:** Especially as the deadline approaches, the contest page will refresh slower and slower. There are 400 students, 11 test cases, and up to 30 seconds per test case. It will only retest a student's code if it has been updated, but many more students will be updating their code causing longer waits. Start early, and don't become reliant on the contest page by testing locally!
 
-## Grading, Submission, and Other Details
-
-Please fully read details on [Academic Honesty](https://courses.engr.illinois.edu/cs241/#/overview#integrity). These are shared between all MPs in CS 241.
-
-You will commit your code to the malloc folder in your subversion repository. Remember to only modify `alloc.c`.
+## Grading
 
 Here is the grading breakdown:
 

--- a/_posts/2016-10-10-password_cracker.md
+++ b/_posts/2016-10-10-password_cracker.md
@@ -278,12 +278,6 @@ When the worker threads finish a task, each thread will print the number of pass
 After all worker threads finish each task, the main thread will print the password (if found), the total number of hashes, the wall clock and CPU time spent on that task, and the ratio of CPU time to wall clock time.
 Note that we have not provided any of the timing print statements in `cracker2`.
 
-## Submission instructions
-As usual, we will use subversion for your submission of this MP.
-Please modify only the following files:
-- `cracker1.c`
-- `cracker2.c`
-
 ## Concept
 
 ### Latency & Throughput

--- a/_posts/2016-10-18-mr0.md
+++ b/_posts/2016-10-18-mr0.md
@@ -194,21 +194,6 @@ For example, if you wanted to count the occurrences of each word in Alice in Won
 
     ./mr0 data/alice.txt test.out ./mapper_wordcount ./reducer_sum
 
-## Grading, Submission, and Other Details
-
-Please fully read details on [Academic Honesty](https://courses.engr.illinois.edu/cs241/#/overview#integrity).
-
-To check out the provided code for map_reduce_0 from the class repository, go to your cs241 directory (the one you checked out for "know your tools") and run:
-
-{% highlight bash %} svn up {% endhighlight %}
-
-If you run ls you will now see a map_reduce_0 folder, where you can find this assignment! To commit your changes (send them to us) type:
-
-{% highlight bash %} svn ci -m "map_reduce_0 submission" {% endhighlight %}
-
-Your repository directory can be viewed from a web browser from the following URL: https://subversion.ews.illinois.edu/svn/fa16-cs241/NETID/mapreduce where NETID is your University NetID.
-It is important to check that the files you expect to be graded are present and up to date in your svn copy
-
 ## Notes
 
 * You may find `dup` and/or `dup2` helpful.

--- a/_posts/2016-10-23-parallel_make.md
+++ b/_posts/2016-10-23-parallel_make.md
@@ -287,19 +287,3 @@ This should generate the same output as:
 {% highlight text %}
     $ make -s -f testfile4 -j 2
 {% endhighlight %}
-
-## Grading, Submission, and Other Details
-
-Please fully read details on [Academic Honesty](https://courses.engr.illinois.edu/cs241/#/overview#integrity).
-These are shared between all MPs in CS 241.
-
-To check out the provided code for parmake from the class repository, go to your cs241 directory (the one you checked out for "know your tools") and run:
-
-{% highlight bash %} svn up {% endhighlight %}
-
-If you run ls you will now see a parmake folder, where you can find this assignment! To commit your changes (send them to us) type:
-
-{% highlight bash %} svn ci -m "parmake submission" {% endhighlight %}
-
-Your repository directory can be viewed from a web browser from the following URL: https://subversion.ews.illinois.edu/svn/fa16-cs241/NETID/parmake where NETID is your University NetID.
-It is important to check that the files you expect to be graded are present and up to date in your svn copy.

--- a/_posts/2016-11-07-mapreduce.md
+++ b/_posts/2016-11-07-mapreduce.md
@@ -354,20 +354,5 @@ With 4 mappers and 4 reducers
 ### Record Setting Pi Code
 As well as the simple mapper/reducer pairs, we also have also included some really cool pi computation code (see [this](http://www.karrels.org/pi/) for more info).
 For instructions on how to use the pi code, see the file `pi/README.txt`.
-Note that we don't currently compile this with an NVIDIA compiler, so you won't be able to use the CUDA version of this code (which we haven't tested) unless you fiddle with the `Makefile`.
-
-## Grading, Submission, and Other Details
-
-Please fully read details on [Academic Honesty](http://cs241.cs.illinois.edu/#academic-integrity).
-These are shared between all MPs in CS 241.
-
-To check out the provided code for mapreduce from the class repository, go to your cs241 directory (the one you checked out for "know your tools") and run:
-
-{% highlight bash %} svn up {% endhighlight %}
-
-If you run ls you will now see a mapreduce folder, where you can find this assignment! To commit your changes (send them to us) type:
-
-{% highlight bash %} svn ci -m "mapreduce submission" {% endhighlight %}
-
-Your repository directory can be viewed from a web browser from the following URL: https://subversion.ews.illinois.edu/svn/fa16-cs241/NETID/mapreduce where NETID is your University NetID.
-It is important to check that the files you expect to be graded are present and up to date in your svn copy.
+Note that we do not currently compile this with an NVIDIA compiler, so you will
+not be able to use the CUDA version of this code (which we have not tested) unless you fiddle with the `Makefile`.


### PR DESCRIPTION
This branch aims to add a "submission instructions" to every assignment documentation. 

Also updated the configs so that we don't have things like "fa16" all over the docs that will need to be updated ever semester.

Please make sure that I 
* Removed the "Grading, Submission, and Other Details" from the docs themselves
* Used proper spelling and grammar
* Made it so that "Submission Instructions" does not show up for non assignment docs pages (like the syllabus) 
* Didn't do anything to dumb

I will be branching off this to make "graded files" and "learning objectives" part of the assignment template
