### PR TITLE
Repair Broken Mobile Menu

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,10 @@
 <!-- Mathjax takes a while to load so do a lazy load to so we can get accessibility -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML" crossorigin="anonymous"></script>
 
+<!-- Bring in JQuery and Bootstrap -->
+<script src="https://code.jquery.com/jquery-3.2.1.min.js" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/js/bootstrap.min.js" crossorigin="anonymous"></script>
+
 <!-- Again bust cache on the main.js file -->
 <script src="/js/main.js?v='{{ site.time }}'"></script>
 

--- a/_pages/malloc_contest.html
+++ b/_pages/malloc_contest.html
@@ -35,7 +35,6 @@
     </div>
     <link rel="stylesheet" href="/css/malloc.css?v={{ site.time }}">
   {% include footer.html %}
-  <script src="https://code.jquery.com/jquery-3.2.1.min.js" crossorigin="anonymous"></script>
   <script type="text/javascript" src="/js/malloc.js?v={{ site.time }}"></script>
 </body>
 </html>

--- a/_pages/search.html
+++ b/_pages/search.html
@@ -30,7 +30,6 @@
     </div>
     <div class="loader">Loading...</div>
     {% include footer.html %}
-    <script src="https://code.jquery.com/jquery-3.2.1.min.js" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lunr.js/2.0.1/lunr.min.js"></script>
     <script src="./js/search.js"></script>
   </div>


### PR DESCRIPTION
## Summary
This is a potentially naive way of repairing the broken mobile menu by adding back in the JQuery and Bootstrap JS CDN calls. While a quick fix, this does indeed get the job done.

## Notes
A potentially 'cleverer' way fixing this issue would be to strip out only what we need from Bootstrap JS (regarding the menu dropdown) and strip out the JQuery within it. We then could add that reduced code without external dependencies to something like `main.js` to speed up load times!