### PR TITLE
Revert primary color to blue

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,5 +1,5 @@
 :root {
-  --color-primary:#13bb36;
+  --color-primary: #2c72ad;
   --color-secondary: #2f5fffdc;
   --color-text: black;
 }


### PR DESCRIPTION
Keeps the primary color (i.e. of the navbar) as the original blue shade for now.