### PR TITLE
Changed mini_valgrind to mini_memcheck to fix the slides and handout

### DIFF
--- a/_data/assignments.yaml
+++ b/_data/assignments.yaml
@@ -46,10 +46,10 @@ labs:
       worksheet: true
       visible: true
   -
-      name: "Mini Valgrind"
+      name: "Mini Memcheck"
       releaseDate: "Week 4"
       dueDate: "Week 5"
-      url: "mini_valgrind"
+      url: "mini_memcheck"
       submissions:
         - title: Entire Assignment
           due_date: 2020-02-19 23:59


### PR DESCRIPTION
This should fix the handout and slide links for the lab on the assignments page.
NOTE: This will break the link to the documentation if the assignment-docs file's name isn't changed from mini_valgrind to mini_memcheck before merging this in.