### PR TITLE
Added specific invalid usage for env in uu

### DIFF
--- a/_docs/utilities_unleashed.md
+++ b/_docs/utilities_unleashed.md
@@ -106,7 +106,10 @@ Please re-read this section *multiple* times before starting:
 * Each execution must be done with `fork`, `exec,` and `wait`.
 * The last variable/value(s) pairing is followed by a `--`.
 * *Everything* following the `--` is the command and any arguments that will be executed by env.
-* Invalid input should result in the usage being printed. It is your job to enforce correct usage! You shouldn't ignore bad usage.
+* Invalid input should result in the usage being printed. Invalid usage includes:
+  - Cannot find `--` in arguments
+  - Cannot find `=` in an variable argument
+  - Cannot find `cmd` after `--`
 
 This is the canonical example and a practical use case:
 


### PR DESCRIPTION
The input is invalid if:
 - Doesn't have `--` in arguments
 - Doesn't have `=` in arguments that are before `--`
 - Doesn't have any argument after `--`