### PR TITLE
making changes to schedule to match ClassTranscribe

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -6,10 +6,10 @@
 
 ## Installing
 
-First make sure you have ruby >= 2.4. We recommend using `rvm`
+First make sure you have ruby >= 2.6. We recommend using `rvm`
 
 ```
-rvm use 2.4.5
+rvm use 2.6.0
 ```
 
 After, we recommend bundler to install all the dependencies

--- a/_data/schedule.yaml
+++ b/_data/schedule.yaml
@@ -132,7 +132,7 @@
 -
   title: "Pipes and seeking"
   summary: "Moving data using pipes, seekable streams, named pipes, behavior with fork"
-  resources: ""
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Pipes%2C-Part-1%3A-Introduction-to-pipes'>Introduction to Pipes</a> and <a href='https://github.com/angrave/SystemProgramming/wiki/Pipes%2C-Part-2%3A-Pipe-programming-secrets'>Working with Pipes</a>"
   color: "#009688"
   number: 22
 -
@@ -157,134 +157,98 @@
   resources: ""
   color: "#aaaaaa"
 -
-  title: "Errno. Networking Intro"
+  title: "UDP/TCP"
   summary: "Robust error handling. EINTR. Intro to TCP,UDP,IP"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/POSIX%2C-Part-1%3A-Error-handling'>Error handling</a> and <a href='https://github.com/angrave/SystemProgramming/wiki/Networking%2C-Part-1%3A-Introduction'>Networking Introduction</a>"
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Networking%2C-Part-6%3A-Creating-a-UDP-server'>UDP</a>, <a href='https://github.com/angrave/SystemProgramming/wiki/POSIX%2C-Part-1%3A-Error-handling'>Error handling</a> and <a href='https://github.com/angrave/SystemProgramming/wiki/Networking%2C-Part-1%3A-Introduction'>Networking Introduction</a>"
   color: "#8BC34A"
   number: 24
 -
-  title: "UDP"
-  summary: "UDP"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Networking%2C-Part-6%3A-Creating-a-UDP-server'>UDP</a>."
-  color: "#FFC107"
-  number: 25
--
-  title: "TCP"
+  title: "TCP Client"
   summary: "TCP/IP Header. IPv4 exhaustion. A web client"
   resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki#8-networking'>Networking</a>"
   color: "#8BC34A"
-  number: 26
+  number: 25
 -
   title: "TCP Server"
   summary: "Passive sockets. The 4 server calls and what they do. Gotchas."
   resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Networking%2C-Part-4%3A-Building-a-simple-TCP-Server'>TCP Server</a>"
   color: "#8BC34A"
+  number: 26
+-
+  title: "Files"
+  summary: "ext2/3/4 filesystem, index nodes (inodes), superbocks, ZFS / BtrFS"
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/File-System%2C-Part-1%3A-Introduction'>Files</a>."
+  color: "#FFC107"
   number: 27
 -
-  title: "TCP Server II"
-  summary: "Socket Programming Gotchas. Intro to scheduling"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Networking%2C-Part-4%3A-Building-a-simple-TCP-Server'>TCP Server</a>"
-  color: "#8BC34A"
+  title: "Files 2"
+  summary: "ext2/3/4 filesystem, index nodes (inodes), superbocks, ZFS / BtrFS"
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/File-System%2C-Part-1%3A-Introduction'>Files</a>."
+  color: "#FFC107"
   number: 28
 -
-  title: "Pipes and Files"
-  summary: "POSIX Pipes and random access files"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Pipes%2C-Part-1%3A-Introduction-to-pipes'>Introduction to Pipes</a> and <a href='https://github.com/angrave/SystemProgramming/wiki/Pipes%2C-Part-2%3A-Pipe-programming-secrets'>Working with Pipes</a>"
-  color: "#4CAF50"
-  number: 29
--
-  title: "Pipes, Files, VM II"
-  summary: "POSIX Pipes, files, memory II"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Files%2C-Part-1%3A-Working-with-files'>Files</a>"
-  color: "#4CAF50"
-  number: 30
--
-  title: "Files-1"
-  summary: "ext2/3/4 filesystem, index nodes (inodes), superbocks, ZFS / BtrFS"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/File-System%2C-Part-1%3A-Introduction'>Files</a>."
-  color: "#FFC107"
-  number: 31
--
-  title: "Files-2"
-  summary: "ext2/3/4 filesystem, index nodes (inodes), superbocks, ZFS / BtrFS"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/File-System%2C-Part-1%3A-Introduction'>Files</a>."
-  color: "#FFC107"
-  number: 32
--
-  title: "Files-3"
+  title: "Files 3"
   summary: "Symbolic links, hard links, directory searching, intro to permissions"
   resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/File-System%2C-Part-3%3A-Permissions'>Permissions</a>."
   color: "#FFC107"
-  number: 33
+  number: 29
 -
-  title: "Files-4"
+  title: "Files 4"
   summary: "File permissions, directories, file globbing, intro to RAID"
   resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/File-System%2C-Part-3%3A-Permissions'>Permissions</a>."
   color: "#FFC107"
-  number: 34
+  number: 30
 -
   title: "Files-5"
   summary: "Redundant Array of Inexpensive Disks (RAID), the various RAID levels"
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/File-System%2C-Part-6%3A-Memory-mapped-files-and-Shared-memory'>Memory Mapped</a>."
+  color: "#FFC107"
+  number: 31
+-
+  title: "Scheduling and Scheduling Algorithms"
+  summary: "Scheduling examples"
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Scheduling%2C-Part-1%3A-Scheduling-Processes'>Scheduling</a> and <a href='https://github.com/angrave/SystemProgramming/wiki/Scheduling%2C-Part-2%3A-Scheduling-Processes%3A-Algorithms'>Scheduling Algorithms</a>."
+  color: "#CDDC39"
+  number: 32
+-
+  title: "Epoll"
+  summary: "Intro to select, poll, and epoll"
+  resources: ""
+  color: "#C38A80"
+  number: 33
+-
+  title: "Disks and Signals"
+  summary: "Disks and Signals"
+  resources: ""
+  color: "#FFC107"
+  number: 34
+-
+  title: "Working with Signals"
+  summary: "Working with Signals"
   resources: ""
   color: "#FFC107"
   number: 35
 -
-  title: "Scheduling"
-  summary: "Scheduling examples"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Scheduling%2C-Part-1%3A-Scheduling-Processes'>Scheduling</a>"
-  color: "#CDDC39"
+  title: "Networking Protocols"
+  summary: "TCP handshakes, QUIC, HTTP/1.1"
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki#8-networking'>Networking</a>"
+  color: "#FFC107"
   number: 36
 -
-  title: "Scheduling-2"
-  summary: "Scheduling simulator. epoll"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Scheduling%2C-Part-2%3A-Scheduling-Processes%3A-Algorithms'>Scheduling</a>."
-  color: "#CDDC39"
+  title: "RPC"
+  summary: "Remote Procedure Calls"
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/RPC%2C-Part-1%3A-Introduction-to-Remote-Procedure-Calls'>RPC</a>."
+  color: "#FFC107"
   number: 37
 -
-  title: "Web servers and scheduling"
-  summary: "Intro to select, poll, and epoll"
+  title: "Systems Concepts Review"
+  summary: "Systems Concepts Review"
   resources: ""
-  color: "#C38A80"
+  color: "#FFC107"
   number: 38
 -
-  title: "Mmap"
-  summary: "Memory mapped files"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/File-System%2C-Part-6%3A-Memory-mapped-files-and-Shared-memory'>Memory Mapped</a>."
-  color: "#FFC107"
-  number: 39
--
-  title: "VFS"
-  summary: "Virtual filesystems"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/File-System%2C-Part-5%3A-Virtual-file-systems'>VFS</a>."
-  color: "#FFC107"
-  number: 40
--
-  title: "Protocols"
-  summary: "TCP handshakes, QUIC, HTTP/1.1"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/RPC%2C-Part-1%3A-Introduction-to-Remote-Procedure-Calls'>RPC</a>."
-  color: "#FFC107"
-  number: 41
--
-  title: "Network Review"
-  summary: "Overview"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki#8-networking'>Networking</a>"
-  color: "#8BC34A"
-  number: 42
--
-  title: "Advanced signals"
-  summary: "Signal sets, checking pending signals, sigaction vs. signal"
-  resources: "See <a href='http://cs241.cs.illinois.edu/coursebook/Signals'>Signals</a> from the coursebook."
-  color: "#C38A80"
-  number: 43
--
-  title: "RPC"
-  summary: "RPC"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/RPC%2C-Part-1%3A-Introduction-to-Remote-Procedure-Calls'>RPC</a>."
-  color: "#FFC107"
-  number: 44
--
-  title: "Security and System Programming"
+  title: "Misc."
   summary: ""
-  resources: "See <a href='http://cs241.cs.illinois.edu/coursebook/Security'>Security</a> chapter of coursebook."
+  resources: ""
   color: "#C38A80"
-  number: 45
+  number: 39

--- a/_data/schedule.yaml
+++ b/_data/schedule.yaml
@@ -136,10 +136,10 @@
   color: "#009688"
   number: 22
 -
-  title: "Scheduling"
-  summary: "Scheduling examples"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Scheduling%2C-Part-1%3A-Scheduling-Processes'>Scheduling</a>"
-  color: "#CDDC39"
+  title: "Chat with Professor Angrave"
+  summary: ""
+  resources: ""
+  color: "#009688"
   number: 23
 -
   title: "No lecture"
@@ -157,133 +157,134 @@
   resources: ""
   color: "#aaaaaa"
 -
-  title: "Scheduling-2"
-  summary: "Scheduling simulator. epoll"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Scheduling%2C-Part-2%3A-Scheduling-Processes%3A-Algorithms'>Scheduling</a>."
-  color: "#CDDC39"
-  number: 24
--
-  title: "Pipes and Files"
-  summary: "POSIX Pipes and random access files"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Pipes%2C-Part-1%3A-Introduction-to-pipes'>Introduction to Pipes</a> and <a href='https://github.com/angrave/SystemProgramming/wiki/Pipes%2C-Part-2%3A-Pipe-programming-secrets'>Working with Pipes</a>"
-  color: "#4CAF50"
-  number: 25
--
-  title: "Pipes, Files, VM II"
-  summary: "POSIX Pipes, files, memory II"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Files%2C-Part-1%3A-Working-with-files'>Files</a>"
-  color: "#4CAF50"
-  number: 26
--
   title: "Errno. Networking Intro"
   summary: "Robust error handling. EINTR. Intro to TCP,UDP,IP"
   resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/POSIX%2C-Part-1%3A-Error-handling'>Error handling</a> and <a href='https://github.com/angrave/SystemProgramming/wiki/Networking%2C-Part-1%3A-Introduction'>Networking Introduction</a>"
   color: "#8BC34A"
-  number: 27
--
-  title: "Files-1"
-  summary: "ext2/3/4 filesystem, index nodes (inodes), superbocks, ZFS / BtrFS"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/File-System%2C-Part-1%3A-Introduction'>Files</a>."
-  color: "#FFC107"
-  number: 28
--
-  title: "No lecture"
-  summary: "No lecture"
-  resources: ""
-  color: "#A8A8A8"
--
-  title: "Files-3"
-  summary: "Symbolic links, hard links, directory searching, intro to permissions"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/File-System%2C-Part-3%3A-Permissions'>Permissions</a>."
-  color: "#FFC107"
-  number: 29
--
-  title: "Files-4"
-  summary: "File permissions, directories, file globbing, intro to RAID"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/File-System%2C-Part-3%3A-Permissions'>Permissions</a>."
-  color: "#FFC107"
-  number: 30
--
-  title: "Files-5"
-  summary: "Redundant Array of Inexpensive Disks (RAID), the various RAID levels"
-  resources: ""
-  color: "#FFC107"
-  number: 31
--
-  title: "TCP"
-  summary: "TCP/IP Header. IPv4 exhaustion. A web client"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki#8-networking'>Networking</a>"
-  color: "#8BC34A"
-  number: 32
--
-  title: "TCP Server"
-  summary: "Passive sockets. The 4 server calls and what they do. Gotchas."
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Networking%2C-Part-4%3A-Building-a-simple-TCP-Server'>TCP Server</a>"
-  color: "#8BC34A"
-  number: 33
--
-  title: "TCP Server II"
-  summary: "Socket Programming Gotchas. Intro to scheduling"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Networking%2C-Part-4%3A-Building-a-simple-TCP-Server'>TCP Server</a>"
-  color: "#8BC34A"
-  number: 34
+  number: 24
 -
   title: "UDP"
   summary: "UDP"
   resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Networking%2C-Part-6%3A-Creating-a-UDP-server'>UDP</a>."
   color: "#FFC107"
+  number: 25
+-
+  title: "TCP"
+  summary: "TCP/IP Header. IPv4 exhaustion. A web client"
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki#8-networking'>Networking</a>"
+  color: "#8BC34A"
+  number: 26
+-
+  title: "TCP Server"
+  summary: "Passive sockets. The 4 server calls and what they do. Gotchas."
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Networking%2C-Part-4%3A-Building-a-simple-TCP-Server'>TCP Server</a>"
+  color: "#8BC34A"
+  number: 27
+-
+  title: "TCP Server II"
+  summary: "Socket Programming Gotchas. Intro to scheduling"
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Networking%2C-Part-4%3A-Building-a-simple-TCP-Server'>TCP Server</a>"
+  color: "#8BC34A"
+  number: 28
+-
+  title: "Pipes and Files"
+  summary: "POSIX Pipes and random access files"
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Pipes%2C-Part-1%3A-Introduction-to-pipes'>Introduction to Pipes</a> and <a href='https://github.com/angrave/SystemProgramming/wiki/Pipes%2C-Part-2%3A-Pipe-programming-secrets'>Working with Pipes</a>"
+  color: "#4CAF50"
+  number: 29
+-
+  title: "Pipes, Files, VM II"
+  summary: "POSIX Pipes, files, memory II"
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Files%2C-Part-1%3A-Working-with-files'>Files</a>"
+  color: "#4CAF50"
+  number: 30
+-
+  title: "Files-1"
+  summary: "ext2/3/4 filesystem, index nodes (inodes), superbocks, ZFS / BtrFS"
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/File-System%2C-Part-1%3A-Introduction'>Files</a>."
+  color: "#FFC107"
+  number: 31
+-
+  title: "Files-2"
+  summary: "ext2/3/4 filesystem, index nodes (inodes), superbocks, ZFS / BtrFS"
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/File-System%2C-Part-1%3A-Introduction'>Files</a>."
+  color: "#FFC107"
+  number: 32
+-
+  title: "Files-3"
+  summary: "Symbolic links, hard links, directory searching, intro to permissions"
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/File-System%2C-Part-3%3A-Permissions'>Permissions</a>."
+  color: "#FFC107"
+  number: 33
+-
+  title: "Files-4"
+  summary: "File permissions, directories, file globbing, intro to RAID"
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/File-System%2C-Part-3%3A-Permissions'>Permissions</a>."
+  color: "#FFC107"
+  number: 34
+-
+  title: "Files-5"
+  summary: "Redundant Array of Inexpensive Disks (RAID), the various RAID levels"
+  resources: ""
+  color: "#FFC107"
   number: 35
 -
-  title: "RPC"
-  summary: "RPC"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/RPC%2C-Part-1%3A-Introduction-to-Remote-Procedure-Calls'>RPC</a>."
-  color: "#FFC107"
+  title: "Scheduling"
+  summary: "Scheduling examples"
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Scheduling%2C-Part-1%3A-Scheduling-Processes'>Scheduling</a>"
+  color: "#CDDC39"
   number: 36
 -
-  title: "Protocols"
-  summary: "TCP handshakes, QUIC, HTTP/1.1"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/RPC%2C-Part-1%3A-Introduction-to-Remote-Procedure-Calls'>RPC</a>."
-  color: "#FFC107"
+  title: "Scheduling-2"
+  summary: "Scheduling simulator. epoll"
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/Scheduling%2C-Part-2%3A-Scheduling-Processes%3A-Algorithms'>Scheduling</a>."
+  color: "#CDDC39"
   number: 37
--
-  title: "Mmap"
-  summary: "Memory mapped files"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/File-System%2C-Part-6%3A-Memory-mapped-files-and-Shared-memory'>Memory Mapped</a>."
-  color: "#FFC107"
-  number: 38
--
-  title: "VFS"
-  summary: "Virtual filesystems"
-  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/File-System%2C-Part-5%3A-Virtual-file-systems'>VFS</a>."
-  color: "#FFC107"
-  number: 39
 -
   title: "Web servers and scheduling"
   summary: "Intro to select, poll, and epoll"
   resources: ""
   color: "#C38A80"
+  number: 38
+-
+  title: "Mmap"
+  summary: "Memory mapped files"
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/File-System%2C-Part-6%3A-Memory-mapped-files-and-Shared-memory'>Memory Mapped</a>."
+  color: "#FFC107"
+  number: 39
+-
+  title: "VFS"
+  summary: "Virtual filesystems"
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/File-System%2C-Part-5%3A-Virtual-file-systems'>VFS</a>."
+  color: "#FFC107"
   number: 40
+-
+  title: "Protocols"
+  summary: "TCP handshakes, QUIC, HTTP/1.1"
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/RPC%2C-Part-1%3A-Introduction-to-Remote-Procedure-Calls'>RPC</a>."
+  color: "#FFC107"
+  number: 41
 -
   title: "Network Review"
   summary: "Overview"
   resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki#8-networking'>Networking</a>"
   color: "#8BC34A"
-  number: 41
+  number: 42
 -
   title: "Advanced signals"
   summary: "Signal sets, checking pending signals, sigaction vs. signal"
   resources: "See <a href='http://cs241.cs.illinois.edu/coursebook/Signals'>Signals</a> from the coursebook."
   color: "#C38A80"
-  number: 42
+  number: 43
+-
+  title: "RPC"
+  summary: "RPC"
+  resources: "See <a href='https://github.com/angrave/SystemProgramming/wiki/RPC%2C-Part-1%3A-Introduction-to-Remote-Procedure-Calls'>RPC</a>."
+  color: "#FFC107"
+  number: 44
 -
   title: "Security and System Programming"
   summary: ""
   resources: "See <a href='http://cs241.cs.illinois.edu/coursebook/Security'>Security</a> chapter of coursebook."
   color: "#C38A80"
-  number: 43
--
-  title: "Finals review"
-  summary: ""
-  resources: "See finals schedule in the <a href='https://courses.illinois.edu/schedule/2019/fall/CS/241'>Course Explorer</a>"
-  color: "#3446EB"
-  number: 44
+  number: 45


### PR DESCRIPTION
I've moved some stuff around to match ClassTranscribe as closely as possible. The numbering doesn't exactly line up because I think lectures used the same handout for multiple days; the CT videos are less than the number of lectures. I wasn't sure how to see the preview for this schedule, so not sure what it might look like. Color scheming was another question - I haven't changed it, but I can change it depending on what we want. 