### PR TITLE
Theme tweaks + schedule update

### DIFF
--- a/_data/schedule.yaml
+++ b/_data/schedule.yaml
@@ -1,246 +1,260 @@
 # Start 1/25. Last Day of I 5/5
-# Non teaching Wed 2/17, Wed 3/24, Tue 4/13 
--
-  title: "Welcome to System Programming"
-  summary: "1. HW0 using my Linux-In-The-Browser minicourse"
-  resources: "See <a href = 'https://github-dev.cs.illinois.edu/angrave/cs241-lectures/blob/master/Welcome.md'>Welcome</a>"
-  color: "#F44336"
-  number: 1
--
-  title: "How to crash in C"
-  summary: "2. Dive into C programming"
-  resources: "See Lecture 2 on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#F44336"
-  number: 2
--
-  title: "C Crash Course 2"
-  summary: "3. man,asprintf,free,assert"
-  resources: "See Lecture 3 on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#F44336"
-  number: 3
--
-  title: "A day at the C side: C Crash Course 3"
-  summary: "4. getenv, scanf, getline, fork "
-  resources: "See lecture 4 on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#F44336"
-  number: 4
--
-  title: "Fork and wait"
-  summary: "5. fork and waitpid"
-  resources: "See lecture 5 <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#E91E63"
-  number: 5
--
-  title: "Forking Processes"
-  summary: "6. The fork-exec-wait pattern"
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#E91E63"
-  number: 6
--
-  title: "Signals for Process Control"
-  summary: "7. Introducing POSIX signals to suspend and kill child processes. SIGSTOP, SIGKILL, SIGINT"
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#E91E63"
-  number: 7
--
-  title: "Thanks for the heap memory"
-  summary: "How to build a memory allocator. Placement algorithms. Fragmentation."
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#9C27B0"
-  number: 8
--
-  title: "Memory allocators I"
-  summary: "Hone your pointer skills when writing malloc and free."
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#9C27B0"
-  number: 9
--
-  title: "Memory allocators II "
-  summary: "Memory allocators part 2."
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#9C27B0"
-  number: 10
--
-  title: "Break"
-  summary: ""
-  resources: ""
-  color: "#808080"
--
-  title: "Threads"
-  summary: "Introducing pthreads. stacks. Concurrency programming gotchas."
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#673AB7"
-  number: 11
--
-  title: "Threads, memory and mutex locks"
-  summary: "Introducing pthreads. stacks, shared memory. creating and joining. Concurrency programming gotchas."
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#673AB7"
-  number: 12
--
-  title: "Mutexes and semaphores"
-  summary: "Why we need Mutex locks and semaphores. Basic usage of pthread implementations. Common gotchas."
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
-  color: "#2196F3"
-  number: 13
--
-  title: "Condition Variables"
-  summary: "Mutex and Condition Variable examples. How to implement a lock (The critical section problem)."
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#2196F3"
-  number: 14
--
-  title: "Critical Section Problem"
-  summary: "Incorrect attempts to solve the Critical Section Problem. Introduction to Condition Variables."
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
-  color: "#2196F3"
-  number: 15
--
-  title: "Condition Variables II"
-  summary: "Condition Variables. Implementing a semaphore using a Condition Variable."
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
-  color: "#2196F3"
-  number: 16
--
-  title: "Producer Consumers. Barriers"
-  summary: "Implementing a barrier. Implementing Producer Consumer."
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#03A9F4"
-  number: 17
--
-  title: "Reader Writer and Deadlock - Part 1"
-  summary: ""
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#03A9F4"
-  number: 18
--
-  title: "Reader Writer and Deadlock - Part 1"
-  summary: ""
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#03A9F4"
-  number: 19
--
-  title: "Dining Philosophers"
-  summary: "The Dining Philosophers problem"
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
-  color: "#00BCD4"
-  number: 20
--
-  title: "Page tables and IPC"
-  summary: "Virtual memory"
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
-  color: "#009688"
-  number: 21
--
-  title: "Pipes and seeking"
-  summary: "Moving data using pipes, seekable streams, named pipes, behavior with fork"
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#009688"
-  number: 22
--
-  title: "Files. Pipes and seeks part 2. "
-  summary: "Working with files"
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#009688"
-  number: 23
--
-  title: "UDP/TCP"
-  summary: "Robust error handling. EINTR. Intro to TCP,UDP,IP"
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#8BC34A"
-  number: 24
--
-  title: "Break"
-  summary: ""
-  resources: ""
-  color: "#808080"
--
-  title: "TCP Client"
-  summary: "TCP/IP Header. IPv4 exhaustion. A web client"
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#8BC34A"
-  number: 25
--
-  title: "TCP Server"
-  summary: "Passive sockets. The 4 server calls and what they do. Gotchas."
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#8BC34A"
-  number: 26
--
-  title: "Files"
-  summary: "ext2/3/4 filesystem, index nodes (inodes), superbocks, ZFS / BtrFS"
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
-  color: "#FFC107"
-  number: 27
--
-  title: "Files 2"
-  summary: "ext2/3/4 filesystem, index nodes (inodes), superbocks, ZFS / BtrFS"
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
-  color: "#FFC107"
-  number: 28
--
-  title: "Files 3"
-  summary: "Symbolic links, hard links, directory searching, intro to permissions"
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
-  color: "#FFC107"
-  number: 29
--
-  title: "Files 4"
-  summary: "File permissions, directories, file globbing, intro to RAID"
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
-  color: "#FFC107"
-  number: 30
--
-  title: "Files-5"
-  summary: "Redundant Array of Inexpensive Disks (RAID), the various RAID levels"
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
-  color: "#FFC107"
-  number: 31
--
-  title: "Scheduling and Scheduling Algorithms"
-  summary: "Scheduling examples"
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
-  color: "#CDDC39"
-  number: 32
--
-  title: "Epoll"
-  summary: "Intro to select, poll, and epoll"
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#C38A80"
-  number: 33 
--
-  title: "Disks and Signals"
-  summary: "Disks and Signals"
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#FFC107"
-  number: 34
--
-  title: "Working with Signals"
-  summary: "Working with Signals"
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#FFC107"
-  number: 35
--
-  title: "Networking Protocols"
-  summary: "TCP handshakes, QUIC, HTTP/1.1"
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#FFC107"
-  number: 36
--
-  title: "RPC"
-  summary: "Remote Procedure Calls"
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
-  color: "#FFC107"
-  number: 37
--
-  title: "Systems Concepts Review"
-  summary: "Systems Concepts Review"
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#FFC107"
-  number: 38
--
-  title: "Misc."
-  summary: ""
-  resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
-  color: "#C38A80"
-  number: 39
+# Non teaching Wed 2/17, Wed 3/24, Tue 4/13
+chapter_link_map:
+  3: "http://cs241.cs.illinois.edu/coursebook/index.html#3-the-c-programming-language-"
+  4: "http://cs241.cs.illinois.edu/coursebook/index.html#4-processes--"
+  5: "http://cs241.cs.illinois.edu/coursebook/index.html#5-memory-allocators-"
+  6: "http://cs241.cs.illinois.edu/coursebook/index.html#6-threads-"
+  7: "http://cs241.cs.illinois.edu/coursebook/index.html#7-synchronization-"
+  8: "http://cs241.cs.illinois.edu/coursebook/index.html#8-deadlock-"
+  9: "http://cs241.cs.illinois.edu/coursebook/index.html#9-virtual-memory-and-interprocess-communication-"
+  10: "http://cs241.cs.illinois.edu/coursebook/index.html#10-scheduling-"
+  11: "http://cs241.cs.illinois.edu/coursebook/index.html#11-networking-"
+  12: "http://cs241.cs.illinois.edu/coursebook/index.html#12-filesystems-"
+  13: "http://cs241.cs.illinois.edu/coursebook/index.html#13-signals-"
+  14: "http://cs241.cs.illinois.edu/coursebook/index.html#14-security-"
+  15: "http://cs241.cs.illinois.edu/coursebook/index.html#15-review-"
+
+classes:
+  - title: "Welcome to System Programming"
+    summary: "1. HW0 using my Linux-In-The-Browser minicourse"
+    review_chapter: 3
+    resources: "See <a href = 'https://github-dev.cs.illinois.edu/angrave/cs241-lectures/blob/master/Welcome.md'>Welcome</a>"
+    color: "#F44336"
+    number: 1
+  - title: "How to crash in C"
+    summary: "2. Dive into C programming"
+    review_chapter: 3
+    resources: "See Lecture 2 on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#F44336"
+    number: 2
+  - title: "C Crash Course 2"
+    summary: "3. man,asprintf,free,assert"
+    review_chapter: 3
+    resources: "See Lecture 3 on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#F44336"
+    number: 3
+  - title: "A day at the C side: C Crash Course 3"
+    summary: "4. getenv, scanf, getline, fork "
+    review_chapter: 3
+    resources: "See lecture 4 on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#F44336"
+    number: 4
+  - title: "Fork and wait"
+    summary: "5. fork and waitpid"
+    review_chapter: 4
+    resources: "See lecture 5 <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#E91E63"
+    number: 5
+  - title: "Forking Processes"
+    summary: "6. The fork-exec-wait pattern"
+    review_chapter: 4
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#E91E63"
+    number: 6
+  - title: "Signals for Process Control"
+    summary: "7. Introducing POSIX signals to suspend and kill child processes. SIGSTOP, SIGKILL, SIGINT"
+    review_chapter: 4
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#E91E63"
+    number: 7
+  - title: "Thanks for the heap memory"
+    summary: "How to build a memory allocator. Placement algorithms. Fragmentation."
+    review_chapter: 5
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#9C27B0"
+    number: 8
+  - title: "Memory allocators I"
+    summary: "Hone your pointer skills when writing malloc and free."
+    review_chapter: 5
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#9C27B0"
+    number: 9
+  - title: "Memory allocators II "
+    summary: "Memory allocators part 2."
+    review_chapter: 5
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#9C27B0"
+    number: 10
+  - title: "Break"
+    summary: ""
+    resources: ""
+    color: "#808080"
+  - title: "Threads"
+    summary: "Introducing pthreads. stacks. Concurrency programming gotchas."
+    review_chapter: 6
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#673AB7"
+    number: 11
+  - title: "Threads, memory and mutex locks"
+    summary: "Introducing pthreads. stacks, shared memory. creating and joining. Concurrency programming gotchas."
+    review_chapter: 6
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#673AB7"
+    number: 12
+  - title: "Mutexes and semaphores"
+    summary: "Why we need Mutex locks and semaphores. Basic usage of pthread implementations. Common gotchas."
+    review_chapter: 7
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
+    color: "#2196F3"
+    number: 13
+  - title: "Condition Variables"
+    summary: "Mutex and Condition Variable examples. How to implement a lock (The critical section problem)."
+    review_chapter: 7
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#2196F3"
+    number: 14
+  - title: "Critical Section Problem"
+    summary: "Incorrect attempts to solve the Critical Section Problem. Introduction to Condition Variables."
+    review_chapter: 7
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
+    color: "#2196F3"
+    number: 15
+  - title: "Condition Variables II"
+    summary: "Condition Variables. Implementing a semaphore using a Condition Variable."
+    review_chapter: 7
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
+    color: "#2196F3"
+    number: 16
+  - title: "Producer Consumers. Barriers"
+    summary: "Implementing a barrier. Implementing Producer Consumer."
+    review_chapter: 7
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#03A9F4"
+    number: 17
+  - title: "Reader Writer and Deadlock - Part 1"
+    summary: ""
+    review_chapter: 8
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#03A9F4"
+    number: 18
+  - title: "Reader Writer and Deadlock - Part 1"
+    summary: ""
+    review_chapter: 8
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#03A9F4"
+    number: 19
+  - title: "Dining Philosophers"
+    summary: "The Dining Philosophers problem"
+    review_chapter: 8
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
+    color: "#00BCD4"
+    number: 20
+  - title: "Page tables and IPC"
+    summary: "Virtual memory"
+    review_chapter: 9
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
+    color: "#009688"
+    number: 21
+  - title: "Pipes and seeking"
+    summary: "Moving data using pipes, seekable streams, named pipes, behavior with fork"
+    review_chapter: 9
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#009688"
+    number: 22
+  - title: "Files. Pipes and seeks part 2. "
+    summary: "Working with files"
+    review_chapter: 9
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#009688"
+    number: 23
+  - title: "UDP/TCP"
+    summary: "Robust error handling. EINTR. Intro to TCP,UDP,IP"
+    review_chapter: 11
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#8BC34A"
+    number: 24
+  - title: "Break"
+    summary: ""
+    resources: ""
+    color: "#808080"
+  - title: "TCP Client"
+    summary: "TCP/IP Header. IPv4 exhaustion. A web client"
+    review_chapter: 11
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#8BC34A"
+    number: 25
+  - title: "TCP Server"
+    summary: "Passive sockets. The 4 server calls and what they do. Gotchas."
+    review_chapter: 11
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#8BC34A"
+    number: 26
+  - title: "Files"
+    summary: "ext2/3/4 filesystem, index nodes (inodes), superbocks, ZFS / BtrFS"
+    review_chapter: 12
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
+    color: "#FFC107"
+    number: 27
+  - title: "Files 2"
+    summary: "ext2/3/4 filesystem, index nodes (inodes), superbocks, ZFS / BtrFS"
+    review_chapter: 12
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
+    color: "#FFC107"
+    number: 28
+  - title: "Files 3"
+    summary: "Symbolic links, hard links, directory searching, intro to permissions"
+    review_chapter: 12
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
+    color: "#FFC107"
+    number: 29
+  - title: "Files 4"
+    summary: "File permissions, directories, file globbing, intro to RAID"
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
+    review_chapter: 12
+    color: "#FFC107"
+    number: 30
+  - title: "Files-5"
+    summary: "Redundant Array of Inexpensive Disks (RAID), the various RAID levels"
+    review_chapter: 12
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
+    color: "#FFC107"
+    number: 31
+  - title: "Scheduling and Scheduling Algorithms"
+    summary: "Scheduling examples"
+    review_chapter: 10
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
+    color: "#CDDC39"
+    number: 32
+  - title: "Epoll"
+    summary: "Intro to select, poll, and epoll"
+    review_chapter: 11
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#C38A80"
+    number: 33
+  - title: "Disks and Signals"
+    summary: "Disks and Signals"
+    review_chapter: 13
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#FFC107"
+    number: 34
+  - title: "Working with Signals"
+    summary: "Working with Signals"
+    review_chapter: 13
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#FFC107"
+    number: 35
+  - title: "Networking Protocols"
+    summary: "TCP handshakes, QUIC, HTTP/1.1"
+    review_chapter: 11
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#FFC107"
+    number: 36
+  - title: "RPC"
+    summary: "Remote Procedure Calls"
+    review_chapter: 11
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>."
+    color: "#FFC107"
+    number: 37
+  - title: "Systems Concepts Review"
+    summary: "Systems Concepts Review"
+    review_chapter: 15
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#FFC107"
+    number: 38
+  - title: "Security (if time)"
+    summary: ""
+    review_chapter: 14
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#C38A80"
+    number: 39

--- a/_data/schedule.yaml
+++ b/_data/schedule.yaml
@@ -258,3 +258,9 @@ classes:
     resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
     color: "#C38A80"
     number: 39
+  - title: "Misc."
+    summary: ""
+    review_chapter: 15
+    resources: "See lecture on <a href = 'https://classtranscribe.illinois.edu/'>ClassTranscribe</a>"
+    color: "#C38A80"
+    number: 40

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -1,42 +1,38 @@
 <!DOCTYPE html>
 <html lang="en">
 {% include head.html %}
+
 <body data-spy="scroll" data-target="#overview" data-offset="50">
-{% include header.html %}
-<div class="container-fluid">
-  <div class="row" style="display: flex; justify-content: stretch;">
+  {% include header.html %}
+  <main>
     <div class="col-sm-3 col-xs-12 hidden-xs" style="min-height: 100%">
       <nav id="overview" data-toggle="toc" class="sticky-top"></nav>
     </div>
     <div class="col-sm-9 col-xs-12">
-      <div class="wrapper">
-        <div class="pad"><div class="card">
-          <div class="title">
-            {% assign split_url = page.url | split: '/' %}
-            {% assign name_no_md = split_url[-1] | replace: '.html','' %}
-            {% assign assign_data = site.assign_by_url[name_no_md] %}
-            <h1>
-              {{ page.title }}
-            </h1>
-          </div>
-          <div class="container-fluid"><div class="row"><div class="content col-sm-11 .col-sm-offset-1">
-            {% if assign_data.submissions %}
-              <div class="submission-wrapper">
-                {% for submission in assign_data.submissions %}
-                  <b>{{ submission.title }}</b> due <b>{{ submission.due_date }}</b><br/>
-                  {% if submission.graded_files %}
-                    <b>Graded files:</b>
-                    <ul>
-                      {% for graded_file in submission.graded_files %}
-                        <li>{{ graded_file }}</li>
-                      {% endfor %}
-                    </ul>
-                  {% endif %}
-                {% endfor %}
-              </div>
-            {% endif %}
-          </div></div></div>
-        </div></div>
+      <div class="title">
+        {% assign split_url = page.url | split: '/' %}
+        {% assign name_no_md = split_url[-1] | replace: '.html','' %}
+        {% assign assign_data = site.assign_by_url[name_no_md] %}
+        <h1>
+          {{ page.title }}
+        </h1>
+      </div>
+      <div class="content col-sm-11 .col-sm-offset-1">
+        {% if assign_data.submissions %}
+        <div class="submission-wrapper">
+          {% for submission in assign_data.submissions %}
+          <b>{{ submission.title }}</b> due <b>{{ submission.due_date }}</b><br />
+          {% if submission.graded_files %}
+          <b>Graded files:</b>
+          <ul>
+            {% for graded_file in submission.graded_files %}
+            <li>{{ graded_file }}</li>
+            {% endfor %}
+          </ul>
+          {% endif %}
+          {% endfor %}
+        </div>
+        {% endif %}
       </div>
       <div class="hidden-sm hidden-md hidden-lg">
         {% if page.toc != false %}
@@ -44,20 +40,19 @@
         {% endif %}
       </div>
       <div id="content">
-          {% include doc_header.html %}
-          {{ content | content_style }}
-          {% capture doc_footer %}{% include doc_footer.md %}{% endcapture %}
-          {{ doc_footer | markdownify | content_style }}
+        {% include doc_header.html %}
+        {{ content | content_style }}
+        {% capture doc_footer %}{% include doc_footer.md %}{% endcapture %}
+        {{ doc_footer | markdownify | content_style }}
       </div>
       <div class="col-md-2 col-sm-1 col-xs-0"></div>
     </div>
-  </div>
-
-  </div>
+  </main>
   {% include footer.html %}
   <script type="application/javascript">
     var github_repo = "{{ site.repository | escape }}";
     var github_path = "{{ page.path | escape }}";
   </script>
 </body>
+
 </html>

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -3,52 +3,56 @@
 {% include head.html %}
 
 <body data-spy="scroll" data-target="#overview" data-offset="50">
-  {% include header.html %}
-  <main>
-    <div class="col-sm-3 col-xs-12 hidden-xs" style="min-height: 100%">
-      <nav id="overview" data-toggle="toc" class="sticky-top"></nav>
-    </div>
-    <div class="col-sm-9 col-xs-12">
-      <div class="title">
-        {% assign split_url = page.url | split: '/' %}
-        {% assign name_no_md = split_url[-1] | replace: '.html','' %}
-        {% assign assign_data = site.assign_by_url[name_no_md] %}
-        <h1>
-          {{ page.title }}
-        </h1>
-      </div>
-      <div class="content col-sm-11 .col-sm-offset-1">
-        {% if assign_data.submissions %}
-        <div class="submission-wrapper">
-          {% for submission in assign_data.submissions %}
-          <b>{{ submission.title }}</b> due <b>{{ submission.due_date }}</b><br />
-          {% if submission.graded_files %}
-          <b>Graded files:</b>
-          <ul>
-            {% for graded_file in submission.graded_files %}
-            <li>{{ graded_file }}</li>
-            {% endfor %}
-          </ul>
-          {% endif %}
-          {% endfor %}
+  <div class="container-fluid">
+    <div class="row" style="display: flex; justify-content: stretch;">
+      {% include header.html %}
+      <div class="row">
+        <div class="col-sm-3 col-xs-12 hidden-xs" style="min-height: 100%">
+          <nav id="overview" data-toggle="toc" class="sticky-top"></nav>
         </div>
-        {% endif %}
+        <div class="col-sm-9 col-xs-12">
+          <div class="title">
+            {% assign split_url = page.url | split: '/' %}
+            {% assign name_no_md = split_url[-1] | replace: '.html','' %}
+            {% assign assign_data = site.assign_by_url[name_no_md] %}
+            <h1>
+              {{ page.title }}
+            </h1>
+          </div>
+          <div class="content col-sm-11 .col-sm-offset-1">
+            {% if assign_data.submissions %}
+            <div class="submission-wrapper">
+              {% for submission in assign_data.submissions %}
+              <b>{{ submission.title }}</b> due <b>{{ submission.due_date }}</b><br />
+              {% if submission.graded_files %}
+              <b>Graded files:</b>
+              <ul>
+                {% for graded_file in submission.graded_files %}
+                <li>{{ graded_file }}</li>
+                {% endfor %}
+              </ul>
+              {% endif %}
+              {% endfor %}
+            </div>
+            {% endif %}
+          </div>
+          <div class="hidden-sm hidden-md hidden-lg">
+            {% if page.toc != false %}
+            {{ content | toc }}
+            {% endif %}
+          </div>
+          <div id="content">
+            {% include doc_header.html %}
+            {{ content | content_style }}
+            {% capture doc_footer %}{% include doc_footer.md %}{% endcapture %}
+            {{ doc_footer | markdownify | content_style }}
+          </div>
+          <div class="col-md-2 col-sm-1 col-xs-0"></div>
+        </div>
+        {% include footer.html %}
       </div>
-      <div class="hidden-sm hidden-md hidden-lg">
-        {% if page.toc != false %}
-        {{ content | toc }}
-        {% endif %}
-      </div>
-      <div id="content">
-        {% include doc_header.html %}
-        {{ content | content_style }}
-        {% capture doc_footer %}{% include doc_footer.md %}{% endcapture %}
-        {{ doc_footer | markdownify | content_style }}
-      </div>
-      <div class="col-md-2 col-sm-1 col-xs-0"></div>
     </div>
-  </main>
-  {% include footer.html %}
+  </div>
   <script type="application/javascript">
     var github_repo = "{{ site.repository | escape }}";
     var github_path = "{{ page.path | escape }}";

--- a/_pages/assignments.html
+++ b/_pages/assignments.html
@@ -40,7 +40,7 @@
                 <div class="col-md-5 col-5 col-xs-12">
                     <div class="table-responsive">
                         <h3>MPs</h3>
-                        {% assign released_mps = site.data.assignments['mps'] | where: "visible", "false" %}
+                        {% assign released_mps = site.data.assignments['mps'] | where: "visible", "true" %}
                         {% if released_mps.size == 0 %}
                         <p>No MP released yet. Check back later!</p>
                         {% else %}
@@ -69,7 +69,7 @@
 
                     <div class="table-responsive">
                         <h3>Labs</h3>
-                        {% assign released_labs = site.data.assignments['labs'] | where: "visible", "false" %}
+                        {% assign released_labs = site.data.assignments['labs'] | where: "visible", "true" %}
                         {% if released_labs.size == 0 %}
                         <p>No lab released yet. Check back later!</p>
                         {% else %}

--- a/_pages/assignments.html
+++ b/_pages/assignments.html
@@ -18,111 +18,108 @@
         }
     </style>
     {% include header.html %}
-    <div class="container-fluid">
-        <div class="container-fluid">
+    <main>
+        <div class="col-md-10 col-10 col-xs-12">
+            <h1>Assignments</h1>
+            <section class="infrastructure-links">
+                <p>
+                    <a href="{{ site.data.constants.broadway_on_demand_link }}" target="_blank" class="btn btn-success"
+                        role="button">Broadway On-Demand Autograder</a>
+                </p>
+                {% for mp in site.data.assignments['mps'] %}
+                {% if mp.name == "Malloc" and mp.visible %}
+                <p>
+                    <a href="{{ site.data.constants.malloc_contest_link }}" class="btn btn-warning" role="button">Malloc
+                        Contest</a>
+                </p>
+                {% break %}
+                {% endif %}
+                {% endfor %}
+            </section>
             <div class="row">
-                <div class="col-md-1 col-1 col-xs-0"></div>
-                <div class="col-md-10 col-10 col-xs-12">
-                    <h1>Assignments</h1>
-                    <section class="infrastructure-links">
-                        <p>
-                            <a href="{{ site.data.constants.broadway_on_demand_link }}" target="_blank" class="btn btn-success"
-                                role="button">Broadway On-Demand Autograder</a>
-                        </p>
-                        {% for mp in site.data.assignments['mps'] %}
-                            {% if mp.name == "Malloc" and mp.visible %}
-                                <p>
-                                    <a href="{{ site.data.constants.malloc_contest_link }}" class="btn btn-warning" role="button">Malloc Contest</a>
-                                </p>
-                                {% break %}
-                            {% endif %}
-                        {% endfor %}
-                    </section>
-                    <div class="row">
-
-                        <div class="col-md-5 col-5 col-xs-12">
-                            <div class="table-responsive">
-                                <h3>MPs</h3>
-                                {% assign released_mps = site.data.assignments['mps'] | where: "visible", "true" %}
-                                {% if released_mps.size == 0 %}
-                                    <p>No MP released yet. Check back later!</p>
-                                {% else %}
-                                    <table width="100%" class="table" style="width:90%">
-                                        <thead>
-                                            <tr>
-                                                <th>MP</th>
-                                                <th>Release Date</th>
-                                                <th>End Date</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {% for mp in released_mps %}
-                                            <tr>
-                                                <th scope="row"><a href="/assignments/{{mp.url}}.html">{{mp.name}}</a></th>
-                                                <td>{{mp.releaseDate}}</td>
-                                                <td>{{mp.dueDate}}</td>
-                                            </tr>
-                                            {% endfor %}
-                                        </tbody>
-                                    </table>
-                                {% endif %}
-                            </div>
-                        </div>
-                        <div class="col-md-7 col-7 col-xs-12">
-
-                            <div class="table-responsive">
-                                <h3>Labs</h3>
-                                {% assign released_labs = site.data.assignments['labs'] | where: "visible", "true" %}
-                                {% if released_labs.size == 0 %}
-                                    <p>No lab released yet. Check back later!</p>
-                                {% else %}
-                                    <table class="table" style="width:90%">
-                                        <thead>
-                                            <tr>
-                                                <th>Lab</th>
-                                                <th>Release Date</th>
-                                                <th>Due Date</th>
-                                                <th>Slides</th>
-                                                <th>Handout</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {% for lab in released_labs %}
-                                            <tr>
-                                                <th scope="row"><a href="/assignments/{{lab.url}}.html">{{lab.name}}</a></th>
-                                                <td>{{lab.releaseDate}}</td>
-                                                <td>{{lab.dueDate}}</td>
-                                                {% if lab.resources %} {% if lab.slides == nil or lab.slides != false %}
-                                                <td>
-                                                    <a href="/slides/{{lab.url}}.html" class="fancy-link wiki-link"><img src="./images/lab-icons/animation.png" alt='Slides'></a>
-                                                </td>
-                                                {% else %}
-                                                <td></td>
-                                                {% endif %} {% if lab.worksheet == nil or lab.worksheet != false %}
-                                                <td>
-                                                    <a href="/resources/handouts/{{lab.url}}.pdf" class="fancy-link wiki-link"><img src="./images/lab-icons/file-document.png" alt='Handout'></a>
-                                                </td>
-                                                {% else %}
-                                                <td></td>
-                                                {% endif %} {% else %}
-                                                <td class="mdl-data-table__cell--non-numeric">
-                                                </td>
-                                                <td class="mdl-data-table__cell--non-numeric">
-                                                </td>
-                                                {% endif %}
-                                            </tr>
-                                            {% endfor %}
-                                        </tbody>
-                                    </table>
-                                {% endif %}
-                            </div>
-                        </div>
+                <div class="col-md-5 col-5 col-xs-12">
+                    <div class="table-responsive">
+                        <h3>MPs</h3>
+                        {% assign released_mps = site.data.assignments['mps'] | where: "visible", "false" %}
+                        {% if released_mps.size == 0 %}
+                        <p>No MP released yet. Check back later!</p>
+                        {% else %}
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>MP</th>
+                                    <th>Release Date</th>
+                                    <th>End Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for mp in released_mps %}
+                                <tr>
+                                    <th scope="row"><a href="/assignments/{{mp.url}}.html">{{mp.name}}</a></th>
+                                    <td>{{mp.releaseDate}}</td>
+                                    <td>{{mp.dueDate}}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                        {% endif %}
                     </div>
-                    <div class="col-md-3 col-1 col-xs-0"></div>
+                </div>
+                <div class="col-md-7 col-7 col-xs-12">
+
+                    <div class="table-responsive">
+                        <h3>Labs</h3>
+                        {% assign released_labs = site.data.assignments['labs'] | where: "visible", "false" %}
+                        {% if released_labs.size == 0 %}
+                        <p>No lab released yet. Check back later!</p>
+                        {% else %}
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Lab</th>
+                                    <th>Release Date</th>
+                                    <th>Due Date</th>
+                                    <th>Slides</th>
+                                    <th>Handout</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for lab in released_labs %}
+                                <tr>
+                                    <th scope="row"><a href="/assignments/{{lab.url}}.html">{{lab.name}}</a></th>
+                                    <td>{{lab.releaseDate}}</td>
+                                    <td>{{lab.dueDate}}</td>
+                                    {% if lab.resources %} {% if lab.slides == nil or lab.slides != false %}
+                                    <td>
+                                        <a href="/slides/{{lab.url}}.html" class="fancy-link wiki-link"><img
+                                                src="./images/lab-icons/animation.png" alt='Slides'></a>
+                                    </td>
+                                    {% else %}
+                                    <td></td>
+                                    {% endif %} {% if lab.worksheet == nil or lab.worksheet != false %}
+                                    <td>
+                                        <a href="/resources/handouts/{{lab.url}}.pdf" class="fancy-link wiki-link"><img
+                                                src="./images/lab-icons/file-document.png" alt='Handout'></a>
+                                    </td>
+                                    {% else %}
+                                    <td></td>
+                                    {% endif %} {% else %}
+                                    <td class="mdl-data-table__cell--non-numeric">
+                                    </td>
+                                    <td class="mdl-data-table__cell--non-numeric">
+                                    </td>
+                                    {% endif %}
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                        {% endif %}
+                    </div>
                 </div>
             </div>
-        </div>
-        {% include footer.html %}
+            <div class="col-md-3 col-1 col-xs-0"></div>
+    </main>
+    {% include footer.html %}
 </body>
 
 </html>

--- a/_pages/assignments.html
+++ b/_pages/assignments.html
@@ -18,108 +18,105 @@
         }
     </style>
     {% include header.html %}
-    <main>
-        <div class="col-md-10 col-10 col-xs-12">
-            <h1>Assignments</h1>
-            <section class="infrastructure-links">
-                <p>
-                    <a href="{{ site.data.constants.broadway_on_demand_link }}" target="_blank" class="btn btn-success"
-                        role="button">Broadway On-Demand Autograder</a>
-                </p>
-                {% for mp in site.data.assignments['mps'] %}
-                {% if mp.name == "Malloc" and mp.visible %}
-                <p>
-                    <a href="{{ site.data.constants.malloc_contest_link }}" class="btn btn-warning" role="button">Malloc
-                        Contest</a>
-                </p>
-                {% break %}
-                {% endif %}
-                {% endfor %}
-            </section>
-            <div class="row">
-                <div class="col-md-5 col-5 col-xs-12">
-                    <div class="table-responsive">
-                        <h3>MPs</h3>
-                        {% assign released_mps = site.data.assignments['mps'] | where: "visible", "true" %}
-                        {% if released_mps.size == 0 %}
-                        <p>No MP released yet. Check back later!</p>
-                        {% else %}
-                        <table>
-                            <thead>
-                                <tr>
-                                    <th>MP</th>
-                                    <th>Release Date</th>
-                                    <th>End Date</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {% for mp in released_mps %}
-                                <tr>
-                                    <th scope="row"><a href="/assignments/{{mp.url}}.html">{{mp.name}}</a></th>
-                                    <td>{{mp.releaseDate}}</td>
-                                    <td>{{mp.dueDate}}</td>
-                                </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
-                        {% endif %}
-                    </div>
-                </div>
-                <div class="col-md-7 col-7 col-xs-12">
-
-                    <div class="table-responsive">
-                        <h3>Labs</h3>
-                        {% assign released_labs = site.data.assignments['labs'] | where: "visible", "true" %}
-                        {% if released_labs.size == 0 %}
-                        <p>No lab released yet. Check back later!</p>
-                        {% else %}
-                        <table>
-                            <thead>
-                                <tr>
-                                    <th>Lab</th>
-                                    <th>Release Date</th>
-                                    <th>Due Date</th>
-                                    <th>Slides</th>
-                                    <th>Handout</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {% for lab in released_labs %}
-                                <tr>
-                                    <th scope="row"><a href="/assignments/{{lab.url}}.html">{{lab.name}}</a></th>
-                                    <td>{{lab.releaseDate}}</td>
-                                    <td>{{lab.dueDate}}</td>
-                                    {% if lab.resources %} {% if lab.slides == nil or lab.slides != false %}
-                                    <td>
-                                        <a href="/slides/{{lab.url}}.html" class="fancy-link wiki-link"><img
-                                                src="./images/lab-icons/animation.png" alt='Slides'></a>
-                                    </td>
-                                    {% else %}
-                                    <td></td>
-                                    {% endif %} {% if lab.worksheet == nil or lab.worksheet != false %}
-                                    <td>
-                                        <a href="/resources/handouts/{{lab.url}}.pdf" class="fancy-link wiki-link"><img
-                                                src="./images/lab-icons/file-document.png" alt='Handout'></a>
-                                    </td>
-                                    {% else %}
-                                    <td></td>
-                                    {% endif %} {% else %}
-                                    <td class="mdl-data-table__cell--non-numeric">
-                                    </td>
-                                    <td class="mdl-data-table__cell--non-numeric">
-                                    </td>
-                                    {% endif %}
-                                </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
-                        {% endif %}
-                    </div>
+    <div class="col-md-10 col-10 col-xs-12">
+        <h1>Assignments</h1>
+        <section class="infrastructure-links">
+            <p>
+                <a href="{{ site.data.constants.broadway_on_demand_link }}" target="_blank" class="btn btn-success"
+                    role="button">Broadway On-Demand Autograder</a>
+            </p>
+            {% for mp in site.data.assignments['mps'] %}
+            {% if mp.name == "Malloc" and mp.visible %}
+            <p>
+                <a href="{{ site.data.constants.malloc_contest_link }}" class="btn btn-warning" role="button">Malloc
+                    Contest</a>
+            </p>
+            {% break %}
+            {% endif %}
+            {% endfor %}
+        </section>
+        <div class="row">
+            <div class="col-md-5 col-5 col-xs-12">
+                <div class="table-responsive">
+                    <h3>MPs</h3>
+                    {% assign released_mps = site.data.assignments['mps'] | where: "visible", "true" %}
+                    {% if released_mps.size == 0 %}
+                    <p>No MP released yet. Check back later!</p>
+                    {% else %}
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>MP</th>
+                                <th>Release Date</th>
+                                <th>End Date</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for mp in released_mps %}
+                            <tr>
+                                <th scope="row"><a href="/assignments/{{mp.url}}.html">{{mp.name}}</a></th>
+                                <td>{{mp.releaseDate}}</td>
+                                <td>{{mp.dueDate}}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    {% endif %}
                 </div>
             </div>
-            <div class="col-md-3 col-1 col-xs-0"></div>
-    </main>
-    {% include footer.html %}
-</body>
+            <div class="col-md-7 col-7 col-xs-12">
 
+                <div class="table-responsive">
+                    <h3>Labs</h3>
+                    {% assign released_labs = site.data.assignments['labs'] | where: "visible", "true" %}
+                    {% if released_labs.size == 0 %}
+                    <p>No lab released yet. Check back later!</p>
+                    {% else %}
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Lab</th>
+                                <th>Release Date</th>
+                                <th>Due Date</th>
+                                <th>Slides</th>
+                                <th>Handout</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for lab in released_labs %}
+                            <tr>
+                                <th scope="row"><a href="/assignments/{{lab.url}}.html">{{lab.name}}</a></th>
+                                <td>{{lab.releaseDate}}</td>
+                                <td>{{lab.dueDate}}</td>
+                                {% if lab.resources %} {% if lab.slides == nil or lab.slides != false %}
+                                <td>
+                                    <a href="/slides/{{lab.url}}.html" class="fancy-link wiki-link"><img
+                                            src="./images/lab-icons/animation.png" alt='Slides'></a>
+                                </td>
+                                {% else %}
+                                <td></td>
+                                {% endif %} {% if lab.worksheet == nil or lab.worksheet != false %}
+                                <td>
+                                    <a href="/resources/handouts/{{lab.url}}.pdf" class="fancy-link wiki-link"><img
+                                            src="./images/lab-icons/file-document.png" alt='Handout'></a>
+                                </td>
+                                {% else %}
+                                <td></td>
+                                {% endif %} {% else %}
+                                <td class="mdl-data-table__cell--non-numeric">
+                                </td>
+                                <td class="mdl-data-table__cell--non-numeric">
+                                </td>
+                                {% endif %}
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3 col-1 col-xs-0"></div>
+        {% include footer.html %}
+</body>
 </html>

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -18,7 +18,7 @@ title: Home
         </h1>
       </section>
       <section class="latest-assignments">
-            <h2>
+            <h2 class="centered">
                 Latest Assignments
             </h2>
             <section class="flexbox">
@@ -168,7 +168,6 @@ title: Home
                         <strong>Final Exam: </strong>25% (comprehensive)
                     </p>
                 </section>
-            </section>
                 <section class="flexbox-item">
                     <h2>
                         Course Prerequisites

--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -5,7 +5,10 @@ title: Resources
 
 # Resources
 
-**If you added late, check [this page]({% link _pages/late_add.md %}) to get caught up.**
+## Late Add Instructions
+If you added late, check [this page]({% link _pages/late_add.md %}) to get caught up.
+
+## Textbook References
 
 An introduction to system programming is Angrave's [CS 241 Crowd-Sourced Wikibook](https://github.com/angrave/SystemProgramming/wiki).
 We also have the second iteration the [Coursebook](https://github.com/illinois-cs241/coursebook/wiki) That provides html, pdf, and wiki versions. Angrave's mini searchable video-introduction and playful _system programming-in-the-browser_ environment is at:

--- a/_pages/schedule.html
+++ b/_pages/schedule.html
@@ -6,89 +6,92 @@
 
 <body>
     {% include header.html %}
-    <h1 class="heading">Live Exploration Schedule</h1>    
-       <p>Prof. Angrave will be hosting live non-lectures Mondays and Wednesdays 9:30-10:45 on Zoom. (See Piazza for link)</p> 
-    <h1 class="heading">Async Schedule</h1>
-        <div class="container-fluid">
-            <div class="row">
-                <!-- Your content goes here -->
-                <div class="col-sm-12 col-xs-12">
-                    <div class="container-fluid">
+    <main>
+        <h1 class="heading">Live Exploration Schedule</h1>
+        <section class="centered">
+            Prof. Angrave will be hosting live non-lectures Mondays and Wednesdays 9:30-10:45am CT on Zoom (see Piazza for link).
+        </section>
 
-                        <div class="row">
-                            <div class="col-lg-3 hidden-xs"></div>
-                            <div class="col-lg-3 hidden-xs">
-                                <h2>Monday</h2>
-                            </div>
-                            <div class="col-lg-3 hidden-xs">
-                                <h2>Wednesday</h2>
-                            </div>
-                            <div class="col-lg-3 hidden-xs">
-                                <h2>Friday</h2>
-                            </div>
-                        </div>
+        <h1 class="heading">Async Schedule</h1>
+        <!-- Your content goes here -->
+        <div class="col-sm-12 col-xs-12">
+            <div class="col-lg-3 hidden-xs">
+                <h2>Days</h2>
+            </div>
+            <div class="col-lg-3 hidden-xs">
+                <h2>Monday</h2>
+            </div>
+            <div class="col-lg-3 hidden-xs">
+                <h2>Wednesday</h2>
+            </div>
+            <div class="col-lg-3 hidden-xs">
+                <h2>Friday</h2>
+            </div>
+        </div>
 
-                        {% assign days = 3 %}
-                        {% assign weeks_zero_indexed = 15 %}
-                        {% assign pretty_date_format = " [%m/%d/%Y] " %}
-                        {% assign initial_day = "2021-01-25" %}
-                        {% assign initial_day_unix = initial_day | date: "%s" %}
-                        <!--The schedule is considered as a list, of which we visit a window of size days, for each week. 
-                                
-                        <!-- This lets us easily move schedule items in the YAML, without having to change the entire structure of the rest of the YAML file, and/or rename week names and dates.-->
-                        {% for week_number in (0..weeks_zero_indexed) %}
-                            {% assign seconds_diff = week_number | times: 7 | times: 86400 %}
-                            {% assign start_day = initial_day_unix | plus: seconds_diff | date: pretty_date_format %}
+        {% assign days = 3 %}
+        {% assign weeks_zero_indexed = 14 %}
+        {% assign pretty_date_format = " [%m/%d/%Y] " %}
+        {% assign initial_day = "2021-01-25" %}
+        {% assign initial_day_unix = initial_day | date: "%s" %}
+        <!--The schedule is considered as a list, of which we visit a window of size days, for each week.-->
 
-                            {% assign monday_friday_diff = 4 | times: 86400 %}
-                            {% assign seconds_diff = seconds_diff | plus: monday_friday_diff %}
-                            {% assign end_day = initial_day_unix | plus: seconds_diff | date: pretty_date_format %}
-                            <div class="row">
-                                <div class="col-lg-3 announcement-card">
-                                    <div class="day-title row" style="background-color: rgb(64, 64, 64)">
-                                        <div class="day-title-text col-md-12">
-                                            <h3 class="day-title-h3">Week {{ week_number | plus: 1 }}:
-                                                {{ start_day }}-{{ end_day }}</h3>
-                                        </div>
-                                    </div>
-                                </div>
-                                {% assign starting_day_offset = week_number | times: days %}
-                                {% for day in site.data.schedule limit: days offset: starting_day_offset %}
-                                    {% assign lecture_number = starting_day_offset | plus: forloop.index %}
-                                    <div class="col-lg-3 ">
-                                        <div class="day container">
-                                            <div class="day-title row" style="background-color: {{ day.color }}">
-                                                <div class="day-title-text col-md-12">
-                                                    <h3 class="day-title-h3">
-                                                        {% if day.number != null %}
-                                                            {{ day.number }}. 
-                                                        {% endif %}
-                                                        {{day.title}}
-                                                    </h3>
-                                                </div>
-                                            </div>
-                                            <div class="day-summary row">
-                                                <div class="col-xs-10 offset-xs-1">
-                                                    <p>{{day.summary}}</p>
-                                                </div>
-                                                <div class="col-xs-1"></div>
-                                            </div>
-                                            <div class="day-resources row">
-                                                <div class="col-md-10 offset-md-1">
-                                                    <p>{{day.resources}}</p>
-                                                </div>
-                                                <div class="col-md-1"></div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                {% endfor %}
-                            </div>
-                        {% endfor %}
+        <!-- This lets us easily move schedule items in the YAML, without having to change the entire structure of the rest of the YAML file, and/or rename week names and dates.-->
+        {% for week_number in (0..weeks_zero_indexed) %}
+        {% assign seconds_diff = week_number | times: 7 | times: 86400 %}
+        {% assign start_day = initial_day_unix | plus: seconds_diff | date: pretty_date_format %}
+
+        {% assign monday_friday_diff = 4 | times: 86400 %}
+        {% assign seconds_diff = seconds_diff | plus: monday_friday_diff %}
+        {% assign end_day = initial_day_unix | plus: seconds_diff | date: pretty_date_format %}
+            <div class="col-lg-3 announcement-card">
+                <div class="day-title" style="background-color: rgb(64, 64, 64)">
+                    <div class="day-title-text col-md-12">
+                        <h3 class="day-title-h3">Week {{ week_number | plus: 1 }}:
+                            {{ start_day }}-{{ end_day }}</h3>
                     </div>
                 </div>
             </div>
-        </div>
-    </div>
+            {% assign starting_day_offset = week_number | times: days %}
+            {% for day in site.data.schedule.classes limit: days offset: starting_day_offset %}
+            {% assign lecture_number = starting_day_offset | plus: forloop.index %}
+            <div class="col-lg-3 ">
+                <div class="day">
+                    <div class="day-title" style="background-color: {{ day.color }}">
+                        <div class="day-title-text col-md-12">
+                            <h3 class="day-title-h3">
+                                {% if day.number != null %}
+                                {{ day.number }}.
+                                {% endif %}
+                                {{day.title}}
+                            </h3>
+                        </div>
+                    </div>
+                    <div class="day-summary">
+                        <div class="col-xs-10 offset-xs-1">
+                            <p><strong>Topics: </strong>{{day.summary}}</p>
+                        </div>
+                        <div class="col-xs-1"></div>
+                    </div>
+                    <div class="day-coursebook-reading">
+                        <div class="col-xs-10 offset-xs-1">
+                            <p><strong>Coursebook Reading: </strong><a
+                                    href={{site.data.schedule.chapter_link_map[day.review_chapter]}}>Chapter {{
+                                    day.review_chapter }}</a></p>
+                        </div>
+                        <div class="col-xs-1"></div>
+                    </div>
+                    <div class="day-resources">
+                        <div class="col-md-10 offset-md-1">
+                            <p>{{day.resources}}</p>
+                        </div>
+                        <div class="col-md-1"></div>
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+            {% endfor %}
+    </main>
     {% include footer.html %}
 </body>
 

--- a/_pages/schedule.html
+++ b/_pages/schedule.html
@@ -4,7 +4,7 @@
 <html lang="en">
 {% include head.html %}
 
-<body>
+<body style="margin: 0 5% 0">
     {% include header.html %}
     <h1 class="heading">Live Exploration Schedule</h1>
     <section class="centered">
@@ -14,17 +14,17 @@
 
     <h1 class="heading">Asynchronous Schedule</h1>
     <!-- Your content goes here -->
-    <div class="col-sm-12 col-xs-12">
-        <div class="col-lg-3 hidden-xs">
+    <div class="row hidden-xs">
+        <div class="col-md-3 hidden-sm">
             <h2>Days</h2>
         </div>
-        <div class="col-lg-3 hidden-xs">
+        <div class="col-md-3 col-sm-4">
             <h2>Monday</h2>
         </div>
-        <div class="col-lg-3 hidden-xs">
+        <div class="col-md-3 col-sm-4">
             <h2>Wednesday</h2>
         </div>
-        <div class="col-lg-3 hidden-xs">
+        <div class="col-md-3 col-sm-4">
             <h2>Friday</h2>
         </div>
     </div>
@@ -37,6 +37,7 @@
     <!--The schedule is considered as a list, of which we visit a window of size days, for each week.-->
 
     <!-- This lets us easily move schedule items in the YAML, without having to change the entire structure of the rest of the YAML file, and/or rename week names and dates.-->
+    <div class="row schedule-container">
     {% for week_number in (0..weeks_zero_indexed) %}
     {% assign seconds_diff = week_number | times: 7 | times: 86400 %}
     {% assign start_day = initial_day_unix | plus: seconds_diff | date: pretty_date_format %}
@@ -44,53 +45,45 @@
     {% assign monday_friday_diff = 4 | times: 86400 %}
     {% assign seconds_diff = seconds_diff | plus: monday_friday_diff %}
     {% assign end_day = initial_day_unix | plus: seconds_diff | date: pretty_date_format %}
-    <div class="col-lg-3 announcement-card">
-        <div class="day-title" style="background-color: rgb(64, 64, 64)">
-            <div class="day-title-text col-md-12">
-                <h3 class="day-title-h3">Week {{ week_number | plus: 1 }}:
-                    {{ start_day }}-{{ end_day }}</h3>
+        <div class="col-md-3 announcement-card hidden-sm col-xs-12">
+            <div class="day-title" style="background-color: rgb(64, 64, 64)">
+                <div class="day-title-text">
+                    <h3 class="day-title-h3">Week {{ week_number | plus: 1 }}:
+                        {{ start_day }}-{{ end_day }}</h3>
+                </div>
             </div>
         </div>
-    </div>
-    {% assign starting_day_offset = week_number | times: days %}
-    {% for day in site.data.schedule.classes limit: days offset: starting_day_offset %}
-    {% assign lecture_number = starting_day_offset | plus: forloop.index %}
-    <div class="col-lg-3 ">
-        <div class="day">
-            <div class="day-title" style="background-color: {{ day.color }}">
-                <div class="day-title-text col-md-12">
-                    <h3 class="day-title-h3">
-                        {% if day.number != null %}
-                        {{ day.number }}.
-                        {% endif %}
-                        {{day.title}}
-                    </h3>
+        {% assign starting_day_offset = week_number | times: days %}
+        {% for day in site.data.schedule.classes limit: days offset: starting_day_offset %}
+            {% assign lecture_number = starting_day_offset | plus: forloop.index %}
+            <div class="col-md-3 col-sm-4 col-xs-12">
+                <div class="day">
+                    <div class="day-title" style="background-color: {{ day.color }}">
+                        <div class="day-title-text">
+                            <h3 class="day-title-h3">
+                                {% if day.number != null %}
+                                {{ day.number }}.
+                                {% endif %}
+                                {{day.title}}
+                            </h3>
+                        </div>
+                    </div>
+                    <div class="day-summary">
+                        <p><strong>Topics: </strong>{{day.summary}}</p>
+                    </div>
+                    <div class="day-coursebook-reading">
+                        <p><strong>Coursebook Reading: </strong><a
+                                href={{site.data.schedule.chapter_link_map[day.review_chapter]}}>Chapter {{
+                                day.review_chapter }}</a></p>
+                    </div>
+                    <div class="day-resources">
+                        <p>{{day.resources}}</p>
+                    </div>
                 </div>
             </div>
-            <div class="day-summary">
-                <div class="col-xs-10 offset-xs-1">
-                    <p><strong>Topics: </strong>{{day.summary}}</p>
-                </div>
-                <div class="col-xs-1"></div>
-            </div>
-            <div class="day-coursebook-reading">
-                <div class="col-xs-10 offset-xs-1">
-                    <p><strong>Coursebook Reading: </strong><a
-                            href={{site.data.schedule.chapter_link_map[day.review_chapter]}}>Chapter {{
-                            day.review_chapter }}</a></p>
-                </div>
-                <div class="col-xs-1"></div>
-            </div>
-            <div class="day-resources">
-                <div class="col-md-10 offset-md-1">
-                    <p>{{day.resources}}</p>
-                </div>
-                <div class="col-md-1"></div>
-            </div>
-        </div>
-    </div>
+        {% endfor %}
     {% endfor %}
-    {% endfor %}
+    </div>
     {% include footer.html %}
 </body>
 

--- a/_pages/schedule.html
+++ b/_pages/schedule.html
@@ -6,92 +6,91 @@
 
 <body>
     {% include header.html %}
-    <main>
-        <h1 class="heading">Live Exploration Schedule</h1>
-        <section class="centered">
-            Prof. Angrave will be hosting live non-lectures Mondays and Wednesdays 9:30-10:45am CT on Zoom (see Piazza for link).
-        </section>
+    <h1 class="heading">Live Exploration Schedule</h1>
+    <section class="centered">
+        Prof. Angrave will be hosting live non-lectures Mondays and Wednesdays 9:30-10:45am CT on Zoom (see Piazza for
+        link).
+    </section>
 
-        <h1 class="heading">Asynchronous Schedule</h1>
-        <!-- Your content goes here -->
-        <div class="col-sm-12 col-xs-12">
-            <div class="col-lg-3 hidden-xs">
-                <h2>Days</h2>
-            </div>
-            <div class="col-lg-3 hidden-xs">
-                <h2>Monday</h2>
-            </div>
-            <div class="col-lg-3 hidden-xs">
-                <h2>Wednesday</h2>
-            </div>
-            <div class="col-lg-3 hidden-xs">
-                <h2>Friday</h2>
+    <h1 class="heading">Asynchronous Schedule</h1>
+    <!-- Your content goes here -->
+    <div class="col-sm-12 col-xs-12">
+        <div class="col-lg-3 hidden-xs">
+            <h2>Days</h2>
+        </div>
+        <div class="col-lg-3 hidden-xs">
+            <h2>Monday</h2>
+        </div>
+        <div class="col-lg-3 hidden-xs">
+            <h2>Wednesday</h2>
+        </div>
+        <div class="col-lg-3 hidden-xs">
+            <h2>Friday</h2>
+        </div>
+    </div>
+
+    {% assign days = 3 %}
+    {% assign weeks_zero_indexed = 13 %}
+    {% assign pretty_date_format = " [%m/%d/%Y] " %}
+    {% assign initial_day = "2021-01-25" %}
+    {% assign initial_day_unix = initial_day | date: "%s" %}
+    <!--The schedule is considered as a list, of which we visit a window of size days, for each week.-->
+
+    <!-- This lets us easily move schedule items in the YAML, without having to change the entire structure of the rest of the YAML file, and/or rename week names and dates.-->
+    {% for week_number in (0..weeks_zero_indexed) %}
+    {% assign seconds_diff = week_number | times: 7 | times: 86400 %}
+    {% assign start_day = initial_day_unix | plus: seconds_diff | date: pretty_date_format %}
+
+    {% assign monday_friday_diff = 4 | times: 86400 %}
+    {% assign seconds_diff = seconds_diff | plus: monday_friday_diff %}
+    {% assign end_day = initial_day_unix | plus: seconds_diff | date: pretty_date_format %}
+    <div class="col-lg-3 announcement-card">
+        <div class="day-title" style="background-color: rgb(64, 64, 64)">
+            <div class="day-title-text col-md-12">
+                <h3 class="day-title-h3">Week {{ week_number | plus: 1 }}:
+                    {{ start_day }}-{{ end_day }}</h3>
             </div>
         </div>
-
-        {% assign days = 3 %}
-        {% assign weeks_zero_indexed = 14 %}
-        {% assign pretty_date_format = " [%m/%d/%Y] " %}
-        {% assign initial_day = "2021-01-25" %}
-        {% assign initial_day_unix = initial_day | date: "%s" %}
-        <!--The schedule is considered as a list, of which we visit a window of size days, for each week.-->
-
-        <!-- This lets us easily move schedule items in the YAML, without having to change the entire structure of the rest of the YAML file, and/or rename week names and dates.-->
-        {% for week_number in (0..weeks_zero_indexed) %}
-        {% assign seconds_diff = week_number | times: 7 | times: 86400 %}
-        {% assign start_day = initial_day_unix | plus: seconds_diff | date: pretty_date_format %}
-
-        {% assign monday_friday_diff = 4 | times: 86400 %}
-        {% assign seconds_diff = seconds_diff | plus: monday_friday_diff %}
-        {% assign end_day = initial_day_unix | plus: seconds_diff | date: pretty_date_format %}
-            <div class="col-lg-3 announcement-card">
-                <div class="day-title" style="background-color: rgb(64, 64, 64)">
-                    <div class="day-title-text col-md-12">
-                        <h3 class="day-title-h3">Week {{ week_number | plus: 1 }}:
-                            {{ start_day }}-{{ end_day }}</h3>
-                    </div>
+    </div>
+    {% assign starting_day_offset = week_number | times: days %}
+    {% for day in site.data.schedule.classes limit: days offset: starting_day_offset %}
+    {% assign lecture_number = starting_day_offset | plus: forloop.index %}
+    <div class="col-lg-3 ">
+        <div class="day">
+            <div class="day-title" style="background-color: {{ day.color }}">
+                <div class="day-title-text col-md-12">
+                    <h3 class="day-title-h3">
+                        {% if day.number != null %}
+                        {{ day.number }}.
+                        {% endif %}
+                        {{day.title}}
+                    </h3>
                 </div>
             </div>
-            {% assign starting_day_offset = week_number | times: days %}
-            {% for day in site.data.schedule.classes limit: days offset: starting_day_offset %}
-            {% assign lecture_number = starting_day_offset | plus: forloop.index %}
-            <div class="col-lg-3 ">
-                <div class="day">
-                    <div class="day-title" style="background-color: {{ day.color }}">
-                        <div class="day-title-text col-md-12">
-                            <h3 class="day-title-h3">
-                                {% if day.number != null %}
-                                {{ day.number }}.
-                                {% endif %}
-                                {{day.title}}
-                            </h3>
-                        </div>
-                    </div>
-                    <div class="day-summary">
-                        <div class="col-xs-10 offset-xs-1">
-                            <p><strong>Topics: </strong>{{day.summary}}</p>
-                        </div>
-                        <div class="col-xs-1"></div>
-                    </div>
-                    <div class="day-coursebook-reading">
-                        <div class="col-xs-10 offset-xs-1">
-                            <p><strong>Coursebook Reading: </strong><a
-                                    href={{site.data.schedule.chapter_link_map[day.review_chapter]}}>Chapter {{
-                                    day.review_chapter }}</a></p>
-                        </div>
-                        <div class="col-xs-1"></div>
-                    </div>
-                    <div class="day-resources">
-                        <div class="col-md-10 offset-md-1">
-                            <p>{{day.resources}}</p>
-                        </div>
-                        <div class="col-md-1"></div>
-                    </div>
+            <div class="day-summary">
+                <div class="col-xs-10 offset-xs-1">
+                    <p><strong>Topics: </strong>{{day.summary}}</p>
                 </div>
+                <div class="col-xs-1"></div>
             </div>
-            {% endfor %}
-            {% endfor %}
-    </main>
+            <div class="day-coursebook-reading">
+                <div class="col-xs-10 offset-xs-1">
+                    <p><strong>Coursebook Reading: </strong><a
+                            href={{site.data.schedule.chapter_link_map[day.review_chapter]}}>Chapter {{
+                            day.review_chapter }}</a></p>
+                </div>
+                <div class="col-xs-1"></div>
+            </div>
+            <div class="day-resources">
+                <div class="col-md-10 offset-md-1">
+                    <p>{{day.resources}}</p>
+                </div>
+                <div class="col-md-1"></div>
+            </div>
+        </div>
+    </div>
+    {% endfor %}
+    {% endfor %}
     {% include footer.html %}
 </body>
 

--- a/_pages/schedule.html
+++ b/_pages/schedule.html
@@ -12,7 +12,7 @@
             Prof. Angrave will be hosting live non-lectures Mondays and Wednesdays 9:30-10:45am CT on Zoom (see Piazza for link).
         </section>
 
-        <h1 class="heading">Async Schedule</h1>
+        <h1 class="heading">Asynchronous Schedule</h1>
         <!-- Your content goes here -->
         <div class="col-sm-12 col-xs-12">
             <div class="col-lg-3 hidden-xs">

--- a/_pages/staff.html
+++ b/_pages/staff.html
@@ -3,8 +3,10 @@
 <!DOCTYPE html>
 <html lang="en">
 {% include head.html %}
+
 <body>
-{% include header.html %}
+    {% include header.html %}
+    <main>
         <h1 class="heading">
             Course Staff
         </h1>
@@ -14,7 +16,8 @@
                 Please acquaint yourself with our <a href="/help.html#piazza-search-first-dont-post">Piazza policy!</a>
             </p>
             <p>
-                However, if you have a sensitive issue feel free to make a private note on Piazza, or email course staff directly.
+                However, if you have a sensitive issue feel free to make a private note on Piazza, or email course staff
+                directly.
             </p>
         </section>
         <!-- A bit janky: assumes zero or one instructors. Why can't Jekyll have stable sort??? :( -->
@@ -24,24 +27,23 @@
         {% assign photos = site.static_files | where_exp: "file", "file.path contains '/images/staffPhotos/'" %}
         <section class="gallery">
             {% for member in sorted_team %}
-                {% assign photofile = photos | where_exp: "file", "file.path contains member.netid" | first %}
-                {% assign photo = photofile.path | default: "/images/staffPhotos/default.jpg" %}
-                <section class="staff-container">
-                    <a href="mailto:{{member.netid}}@illinois.edu?Subject=CS%20241%20Student" alt="Mail Student">
-                        <div class="staff-image"
-                            id="{{member.netid}}"
-                            data-toggle="tooltip"
-                            data-placement="bottom"
-                            title="{{ member.roles }} {% if member.specialty != '' %}interested in {{ member.specialty }}{% endif %} and has been on staff for {{ member.semesters }}"
-                            style="background-image: url({{ photo }});">
-                        </div>
-                        <div class="staff-name">
-                            {{ member.name }}
-                        </div>
-                    </a>
-                </section>
+            {% assign photofile = photos | where_exp: "file", "file.path contains member.netid" | first %}
+            {% assign photo = photofile.path | default: "/images/staffPhotos/default.jpg" %}
+            <section class="staff-container">
+                <a href="mailto:{{member.netid}}@illinois.edu?Subject=CS%20241%20Student" alt="Mail Student">
+                    <div class="staff-image" id="{{member.netid}}" data-toggle="tooltip" data-placement="bottom"
+                        title="{{ member.roles }} {% if member.specialty != '' %}interested in {{ member.specialty }}{% endif %} and has been on staff for {{ member.semesters }}"
+                        style="background-image: url({{ photo }});">
+                    </div>
+                    <div class="staff-name">
+                        {{ member.name }}
+                    </div>
+                </a>
+            </section>
             {% endfor %}
         </section>
-  {% include footer.html %}
+    </main>
+    {% include footer.html %}
 </body>
+
 </html>

--- a/_pages/staff.html
+++ b/_pages/staff.html
@@ -6,44 +6,42 @@
 
 <body>
     {% include header.html %}
-    <main>
-        <h1 class="heading">
-            Course Staff
-        </h1>
-        <section class="center">
-            <p>
-                Most questions should be asked on Piazza, so that answers can benefit the entire class.
-                Please acquaint yourself with our <a href="/help.html#piazza-search-first-dont-post">Piazza policy!</a>
-            </p>
-            <p>
-                However, if you have a sensitive issue feel free to make a private note on Piazza, or email course staff
-                directly.
-            </p>
+    <h1 class="heading">
+        Course Staff
+    </h1>
+    <section class="center">
+        <p>
+            Most questions should be asked on Piazza, so that answers can benefit the entire class.
+            Please acquaint yourself with our <a href="/help.html#piazza-search-first-dont-post">Piazza policy!</a>
+        </p>
+        <p>
+            However, if you have a sensitive issue feel free to make a private note on Piazza, or email course staff
+            directly.
+        </p>
+    </section>
+    <!-- A bit janky: assumes zero or one instructors. Why can't Jekyll have stable sort??? :( -->
+    {% assign team = site.data.staff | sort: 'netid' | sort: 'instructor', 'last' %}
+    {% assign instructor = team | first %}
+    {% assign sorted_team = team | shift | sort: 'name' | unshift: instructor %}
+    {% assign photos = site.static_files | where_exp: "file", "file.path contains '/images/staffPhotos/'" %}
+    <section class="gallery">
+        {% for member in sorted_team %}
+        {% assign photofile = photos | where_exp: "file", "file.path contains member.netid" | first %}
+        {% assign photo = photofile.path | default: "/images/staffPhotos/default.jpg" %}
+        <section class="staff-container">
+            <a href="mailto:{{member.netid}}@illinois.edu?Subject=CS%20241%20Student" alt="Mail Student">
+                <div class="staff-image" id="{{member.netid}}" data-toggle="tooltip" data-placement="bottom"
+                    title="{{ member.roles }} {% if member.specialty != '' %}interested in {{ member.specialty }}{% endif %} and has been on staff for {{ member.semesters }}"
+                    style="background-image: url({{ photo }});">
+                </div>
+                <div class="staff-name">
+                    {{ member.name }}
+                </div>
+            </a>
         </section>
-        <!-- A bit janky: assumes zero or one instructors. Why can't Jekyll have stable sort??? :( -->
-        {% assign team = site.data.staff | sort: 'netid' | sort: 'instructor', 'last' %}
-        {% assign instructor = team | first %}
-        {% assign sorted_team = team | shift | sort: 'name' | unshift: instructor %}
-        {% assign photos = site.static_files | where_exp: "file", "file.path contains '/images/staffPhotos/'" %}
-        <section class="gallery">
-            {% for member in sorted_team %}
-            {% assign photofile = photos | where_exp: "file", "file.path contains member.netid" | first %}
-            {% assign photo = photofile.path | default: "/images/staffPhotos/default.jpg" %}
-            <section class="staff-container">
-                <a href="mailto:{{member.netid}}@illinois.edu?Subject=CS%20241%20Student" alt="Mail Student">
-                    <div class="staff-image" id="{{member.netid}}" data-toggle="tooltip" data-placement="bottom"
-                        title="{{ member.roles }} {% if member.specialty != '' %}interested in {{ member.specialty }}{% endif %} and has been on staff for {{ member.semesters }}"
-                        style="background-image: url({{ photo }});">
-                    </div>
-                    <div class="staff-name">
-                        {{ member.name }}
-                    </div>
-                </a>
-            </section>
-            {% endfor %}
-        </section>
+        {% endfor %}
+    </section>
     </main>
     {% include footer.html %}
-</body>
 
 </html>

--- a/css/main.css
+++ b/css/main.css
@@ -1,6 +1,6 @@
 :root {
-  --color-primary: hsl(207, 59%, 43%);
-  --color-secondary: hsl(207, 70%, 53%);
+  --color-primary:hsl(174, 100%, 29%);
+  --color-secondary: black;
   --color-emphasis: hsl(204, 100%, 42%);
   --color-text: hsl(0, 0%, 0%);
   --color-translucent: hsla(0, 0%, 0%, 0.3);
@@ -9,7 +9,7 @@
 
 body {
     font-family: Roboto, Helvetica, Arial, sans-serif;
-    background-color: var(--color-pale-white);
+    background-color: white;
     color: var(--color-text);
     padding-bottom: 50px;
     position: relative;
@@ -25,7 +25,7 @@ body {
     border: 0px;
     border-top:none;
     box-shadow:none;
-    margin-bottom: 0;
+    margin: 0 15% 0;
 }
 
 .navbar-default .navbar-brand {
@@ -122,16 +122,16 @@ table {
     height:300px;
     margin-bottom:20px;
     width:100%;
-    background-color: hsl(0, 0%, 100%);
+    background-color: hsl(212deg 100% 90%);
     border-radius:3px; /* Has to be equal to the title border */
 }
 
 .day h1 {
-    color: hsl(240, 8%, 95%);
+    color: white;
 }
 
 .day-summary, .day-resources {
-    color: hsl(0, 0%, 0%);
+    color: var(--color-text)
 }
 
 .day-resources {
@@ -140,7 +140,6 @@ table {
 }
 
 .day-summary {
-    position: absolute;
     top: 75px; /* Related to the .day-title height attr */
 }
 
@@ -149,10 +148,10 @@ table {
 }
 
 .day-title {
+    display: flex;
     padding-top: 5px;
     padding-bottom: 5px;
     border-radius: 3px;
-    height:70px;
 }
 
 .schedule-container {
@@ -615,16 +614,36 @@ section.center {
     padding-top: 0;
 }
 
+section.flexbox {
+    display: flex;
+    justify-content: center;
+    margin: auto;
+    flex-wrap: wrap;
+}
+
+.flexbox-item {
+    display: inline-block;
+    padding: 2vh;
+    margin: 2vh;
+}
+
+
 main {
-    text-align: center;
-    margin: 0;
-    padding: 0;
+    margin: 0 15% 0;
     background-color: white;
+}
+
+.centered {
+    text-align: center;
+}
+
+.row {
+    margin: 0 15% 0;
 }
 
 .card-body {
     background-color: var(--color-pale-white);
-    padding: 2vh;
+    padding: 2vw;
     display: block;
 }
 
@@ -636,30 +655,22 @@ main {
     color: white;
 }
 
-.card-body.course-description {
-
+.course-information, .course-description {
+    padding: 5%;
 }
 
-.card-body.course-information {
-    background-color: white;
+section.course-information section.flexbox {
+    justify-content: left;
+}
+
+section.course-information section.flexbox .flexbox-item {
+    width: 30vw;
+    margin: 0;
+    padding: 0;
 }
 
 h2 {
     font-weight: 200;
-}
-
-section.flexbox {
-    display: flex;
-    justify-content: center;
-    margin: auto;
-    flex-wrap: wrap;
-    width: 90vw;
-}
-
-.flexbox-item {
-    display: inline-block;
-    padding: 2vh;
-    margin: 2vh;
 }
 
 img.logo {
@@ -692,9 +703,7 @@ img.logo {
     display: flex;
     justify-content: center;
     margin: auto;
-    padding: 5vw;
     flex-wrap: wrap;
-    width: 100vw;
 }
 
 .staff {
@@ -751,10 +760,12 @@ section.center {
 }
 
 .latest-mp {
+    text-align: center;
     background-color: rgba(16, 213, 147, 0.85);
 }
 
 .latest-lab {
+    text-align: center;
     background-color: rgba(255, 102, 42, 0.85);
 }
 

--- a/css/main.css
+++ b/css/main.css
@@ -62,7 +62,7 @@ body {
     }
 
     p,li {
-        font-size: 12px;
+        font-size: 16px;
     }
 }
 
@@ -116,29 +116,39 @@ td, th {
     display: inline;
 }
 
+.schedule-container {
+    display: flex; 
+    flex-direction: row; 
+    flex-wrap: wrap; 
+    align-items: stretch;
+    padding: 1rem;
+}
+
+@media (min-width: 550px) {
+    .schedule-container {
+        padding: 1rem 5rem;
+    }
+}
+
 .day {
-    height:300px;
-    margin-bottom:20px;
-    width:100%;
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 20px;
+    height: calc(100% - 20px);
     background-color: hsl(212deg 100% 90%);
-    border-radius:3px; /* Has to be equal to the title border */
+    border-radius: 5px;
 }
 
 .day h1 {
     color: white;
 }
 
-.day-summary, .day-resources {
-    color: var(--color-text)
-}
-
-.day-resources {
-    position: absolute;
-    bottom: 20px; /* has to be equal to the day margin-bottom */
+.day-summary, .day-coursebook-reading, .day-resources{
+    padding: 0.5rem 2rem;
 }
 
 .day-summary {
-    top: 75px; /* Related to the .day-title height attr */
+    padding-top: 1rem;
 }
 
 .day-title-text h3 {
@@ -146,15 +156,27 @@ td, th {
 }
 
 .day-title {
-    display: flex;
-    padding-top: 5px;
-    padding-bottom: 5px;
-    border-radius: 3px;
+    padding: 1rem 1.6rem;
+    border-radius: 5px 5px 0 0;
 }
 
-.schedule-container {
-    margin-left: 20px;
-    margin-right: 20px;
+.announcement-card + div .day-title {
+    border-radius: 0;
+}
+
+@media (min-width: 992px) {
+    .announcement-card .day-title {
+        border-radius: 5px;
+    } 
+}
+
+@media (min-width: 768px) {
+    .schedule-container {
+        padding: 0;
+    }
+    .announcement-card + div .day-title {
+        border-radius: 5px 5px 0 0;
+    }
 }
 
 ul.toc {
@@ -164,15 +186,6 @@ ul.toc {
 
 h1, h2, h3 {
     color: var(--color-secondary);
-}
-
-.announcement-card {
-    background-color: white;
-    border-radius: 5px;
-}
-
-.annoucement-title {
-    margin-top: 5px;
 }
 
 .day-title-h3 {

--- a/css/main.css
+++ b/css/main.css
@@ -14,6 +14,7 @@ body {
     color: var(--color-text);
     padding-bottom: 50px;
     position: relative;
+    margin: 0 15% 0;
 }
 
 .sticky-top {
@@ -614,12 +615,6 @@ section.flexbox {
     margin: 2vh;
 }
 
-
-main {
-    margin: 0 15% 0;
-    background-color: white;
-}
-
 .centered {
     text-align: center;
 }
@@ -731,11 +726,23 @@ section.center {
     padding-top: 0;
 }
 
+@media only screen and (max-width: 900px) {
+    body {
+        margin: 0 5% 0;
+    }
+}
+
 /* For phones */
 @media only screen and (max-width: 480px) {
     body {
         font-size: larger;
+        margin: 0;
     }
+
+    .day-title {
+        width: 100%;
+    }
+
     .staff-container div.staff-image {
         width: 20vh;
         height: 20vh;
@@ -743,10 +750,6 @@ section.center {
 
     .staff-name {
         font-size: 1.25em;
-    }
-
-    main {
-        margin: 2vh;
     }
 
     section.course-information section.flexbox .flexbox-item {

--- a/css/main.css
+++ b/css/main.css
@@ -1,15 +1,16 @@
 :root {
-  --color-primary:hsl(174, 100%, 29%);
+  --color-primary:hsl(0, 100%, 33%);
   --color-secondary: black;
-  --color-emphasis: hsl(204, 100%, 42%);
   --color-text: hsl(0, 0%, 0%);
   --color-translucent: hsla(0, 0%, 0%, 0.3);
   --color-pale-white: hsla(240, 8%, 95%);
+  --color-navbar-text: white;
 }
 
 body {
-    font-family: Roboto, Helvetica, Arial, sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif, Helvetica, Arial, sans-serif;
     background-color: white;
+    font-size: large;
     color: var(--color-text);
     padding-bottom: 50px;
     position: relative;
@@ -25,16 +26,15 @@ body {
     border: 0px;
     border-top:none;
     box-shadow:none;
-    margin: 0 15% 0;
 }
 
 .navbar-default .navbar-brand {
-    color: var(--color-pale-white) !important;
+    color: var(--color-navbar-text) !important;
     font-weight: bold;
 }
 
 .navbar-default .navbar-nav>li>a {
-    color: var(--color-pale-white) !important;
+    color: var(--color-navbar-text) !important;
 }
 
 .navbar-collapse {
@@ -43,16 +43,8 @@ body {
 }
 
 .navbar-brand:hover {
-    color: var(--color-navbar-text) !important;
-}
-
-h1 {
-    padding-bottom:20px;
-    font-size:48px;
-}
-
-h2 {
-    margin-top: 2rem;
+    background: var(--color-primary);
+    color: var(--color-navbar-text);
 }
 
 .navbar-nav, .navbar-nav > ul {
@@ -105,9 +97,14 @@ h2 {
 }
 
 table {
-  @extend .table;
-  width: 100%;
+    @extend .table;
+    width: 100%;
 }
+
+td, th {
+    padding: 1%;
+}
+
 
 .anchor {
     display: none;
@@ -169,7 +166,7 @@ h1, h2, h3 {
 }
 
 .announcement-card {
-    background-color: var(--color-pale-white);
+    background-color: white;
     border-radius: 5px;
 }
 
@@ -178,7 +175,7 @@ h1, h2, h3 {
 }
 
 .day-title-h3 {
-    color: var(--color-pale-white);
+    color: white;
 }
 
 img:not(.emoji) {
@@ -204,7 +201,7 @@ img:not(.emoji) {
     border-radius: 50%;
 }
 .loader {
-    color: var(--color-pale-white);
+    color: white;
     font-size: 11px;
     text-indent: -99999em;
     margin: 55px auto;
@@ -276,10 +273,8 @@ img:not(.emoji) {
 
 .fancy-link {
     text-decoration: none !important;
-    color: var(--color-emphasis);
+    color: var(--color-primary);
     display: inline-block;
-    position: relative;
-    padding-bottom: 0px;
 }
 
 .fancy-link:after {
@@ -309,7 +304,7 @@ img:not(.emoji) {
 }
 
 .navbar-default .navbar-toggle .icon-bar {
-    background-color: var(--color-pale-white);
+    background-color: white;
 }
 
 
@@ -416,10 +411,6 @@ div.highlighter-rouge, figure.highlighter-rouge {
     border-top: 0px;
 }
 
-.table {
-    margin-left: 40px;
-    width:75%;
-}
 .search-icon-div {
     width: initial;
     padding-left: 10px;
@@ -600,10 +591,6 @@ li.navbar-item:hover > a, li.navbar-subitem:hover > a {
 
 .heading {
     text-align: center;
-    font-family: Roboto, Helvetica, sans-serif;
-    font-size: 3em;
-    padding: 1em;
-    padding: 0;
 }
 
 section.center {
@@ -635,10 +622,6 @@ main {
 
 .centered {
     text-align: center;
-}
-
-.row {
-    margin: 0 15% 0;
 }
 
 .card-body {
@@ -750,25 +733,33 @@ section.center {
 
 /* For phones */
 @media only screen and (max-width: 480px) {
+    body {
+        font-size: larger;
+    }
     .staff-container div.staff-image {
         width: 20vh;
         height: 20vh;
     }
+
     .staff-name {
         font-size: 1.25em;
+    }
+
+    main {
+        margin: 2vh;
+    }
+
+    section.course-information section.flexbox .flexbox-item {
+        margin: 0;
     }
 }
 
 .latest-mp {
     text-align: center;
-    background-color: rgba(16, 213, 147, 0.85);
+    border: solid rgba(16, 213, 147, 0.85);
 }
 
 .latest-lab {
     text-align: center;
-    background-color: rgba(255, 102, 42, 0.85);
-}
-
-.latest-assignments section.flexbox-item {
-    border-radius: 4%;
+    border: solid rgba(255, 102, 42, 0.85);
 }


### PR DESCRIPTION
- Added coursebook links to each schedule item
  This is done by adding a new map called chapter_link_map in _data/schedule.yaml, and review_chapter items in each topic item.
  In code, I use the chapter number to grab the relevant coursebook section link from the map.
- Improved formatting of schedule items
   Removed a bunch of bootstrap items with class row/container-fluid etc.
   Added bolded link labels for each thing within a card
   Added a light blue background
   Position of each doesn't depend on height from top, except for the "See ClassTranscribe" link at the bottom of each card
- Made website narrower by 15% horizontally
  Makes it easier to read when it isn't that wide
- Tweaked colors
   Replaced light blue, and faded white, with pure black and white
- Screenshots
![image](https://user-images.githubusercontent.com/13492296/105955664-43feac00-603c-11eb-8cd1-7438ff357839.png)
![image](https://user-images.githubusercontent.com/13492296/105955720-54af2200-603c-11eb-8f9b-6e6052b379e5.png)
![image](https://user-images.githubusercontent.com/13492296/105955752-5ed12080-603c-11eb-8c5d-096498c14add.png)
