### PR TITLE
Update mmap return code documentation

### DIFF
--- a/_docs/mad_mad_access_pattern.md
+++ b/_docs/mad_mad_access_pattern.md
@@ -151,7 +151,7 @@ Error cases:
 + If the data file cannot be read or the first 4 bytes are not
   "BTRE", print a helpful error message and exit with error code 2.
 + If a call to `mmap` fails (for version 2), print a helpful error message
-  and exit with return code 3.
+  and exit with error code 3.
 + Helper functions for the above error cases can be found in `utils.h`.
 
 For each word that is found, print its count and its price, where the

--- a/_docs/mad_mad_access_pattern.md
+++ b/_docs/mad_mad_access_pattern.md
@@ -150,6 +150,9 @@ Error cases:
   message describing the arguments it expects and exit with error code 1.
 + If the data file cannot be read or the first 4 bytes are not
   "BTRE", print a helpful error message and exit with error code 2.
++ If a call to `mmap` fails (for version 2), print a helpful error message
+  and exit with return code 3.
++ Helper functions for the above error cases can be found in `utils.h`.
 
 For each word that is found, print its count and its price, where the
 price is always printed with exactly two digits to the right of the decimal


### PR DESCRIPTION
Currently, the mmap documentation doesn't specify what to do when `mmap` fails, although we have a helper function in `utils.h` for it. We currently don't test for it, but it does cause confusion because students think they're failing the autograder because they didn't handle the `mmap` failure case correctly. This commit includes updated documentation that a) informs students to print a message and return code 3 when `mmap` fails, and b) that the "helpful error messages" are in `utils.h` for clarity's sake.