### PR TITLE
Barrier type specification

### DIFF
--- a/_docs/password_cracker.md
+++ b/_docs/password_cracker.md
@@ -255,7 +255,7 @@ When the number of threads doesn't divide the search space evenly, it's easy to 
 The functions `getSubrange()` and `setStringPosition()` are provided in `utils.h` file to assist you with this. We **require** that you use these functions to match our expected output. We cannot guarantee the correctness of code that does not utilize these functions.
 
 With all the threads working on the same task, you may want to restructure your thread synchronization a little.
-Rather than a queue, you may wish to use a barrier.
+Rather than a queue, you may wish to use a `pthread` barrier.
 
 ```
                 Startup     Task 0..............................   Task 1..............................


### PR DESCRIPTION
Students were confused as to whether they needed to use pthread's version of barrier or make their own for password cracker, so this change modifies the line referencing barrier usage to make it clear that pthread's version is the required one.