### PR TITLE
Update Vagrantfiles for Ubuntu 18 + update some VM-related instructions

### DIFF
--- a/_pages/late_add.md
+++ b/_pages/late_add.md
@@ -24,7 +24,7 @@ To get a sense of going on and where we are in the course, please read **all** t
 
 * Overdue assignment's deadlines will not be extended. **Though, It is in your best interest to read through the assignments that you missed in order to understand them (some of them will build of each other)**
 * Email cs241admin@illinois.edu and say that you have added late (give the date you added if you can remember it).
-* If you haven't received your VM after one busniess day of registration, email engrit-help@illinois.edu and ask them for assistance. You will need git access as well. You can create your repository at [the repository creator](https://edu.cs.illinois.edu/create-ghe-repo/{{site.data.constants.department_code}}{{site.data.constants.course_number}}-{{site.semester}}/) Your repo should be available at
+* You will need git access as well. You can create your repository at [the repository creator](https://edu.cs.illinois.edu/create-ghe-repo/{{site.data.constants.department_code}}{{site.data.constants.course_number}}-{{site.semester}}/) Your repo should be available at
 
 `https://github-dev.cs.illinois.edu/{{ site.data.constants.department_code }}{{site.data.constants.course_number}}-{{site.semester }}/NETID`.
 

--- a/_resources/development/Vagrantfile_2_cores
+++ b/_resources/development/Vagrantfile_2_cores
@@ -3,9 +3,9 @@ APT_FLAGS="-qq -y -o Dpkg::Use-Pty=0"
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get $APT_FLAGS update
-apt-get $APT_FLAGS install clang=1:3.8-33ubuntu3.1 \
-                           libncurses5-dev=6.0+20160213-1ubuntu1 \
-                           valgrind=1:3.11.0-1ubuntu4.2 \
+apt-get $APT_FLAGS install clang=1:6.0-41~exp5~ubuntu1 \
+                           libncurses5-dev=6.1-1ubuntu1.18.04 \
+                           valgrind=1:3.13.0-2ubuntu2.3 \
                            manpages-posix manpages-posix-dev \
                            build-essential git strace tmux vim
 
@@ -28,7 +28,7 @@ fi
 SCRIPT
 
 Vagrant.configure("2") do |config|
-	config.vm.box = "bento/ubuntu-16.04"
+	config.vm.box = "bento/ubuntu-18.04"
 	config.vm.hostname = "cs241"
 	config.vm.provider "virtualbox" do |v|
 		v.name = "CS 241"

--- a/_resources/development/Vagrantfile_4_cores
+++ b/_resources/development/Vagrantfile_4_cores
@@ -3,9 +3,9 @@ APT_FLAGS="-qq -y -o Dpkg::Use-Pty=0"
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get $APT_FLAGS update
-apt-get $APT_FLAGS install clang=1:3.8-33ubuntu3.1 \
-                           libncurses5-dev=6.0+20160213-1ubuntu1 \
-                           valgrind=1:3.11.0-1ubuntu4.2 \
+apt-get $APT_FLAGS install clang=1:6.0-41~exp5~ubuntu1 \
+                           libncurses5-dev=6.1-1ubuntu1.18.04 \
+                           valgrind=1:3.13.0-2ubuntu2.3 \
                            manpages-posix manpages-posix-dev \
                            build-essential git strace tmux vim
 
@@ -28,7 +28,7 @@ fi
 SCRIPT
 
 Vagrant.configure("2") do |config|
-	config.vm.box = "bento/ubuntu-16.04"
+	config.vm.box = "bento/ubuntu-18.04"
 	config.vm.hostname = "cs241"
 	config.vm.provider "virtualbox" do |v|
 		v.name = "CS 241"

--- a/_tutorials/development.md
+++ b/_tutorials/development.md
@@ -8,9 +8,9 @@ learning_objectives:
 ## Development in CS 241
 In this course, we use Virtual Machines (VMs) for all our developmment. We will not support development in any other enviornment (e.g. EWS). We would like to stress that no matter what method you use to develop code for CS 241, test all your final code on your VM. The autograding environment is similar to your VM. Thus even though your code "works" on your machine, it may not work on the VMs and thus for the autograder.
 
-For all registered students in the course, you will receive a VM in the CS Department’s VM Farm provisioned by EngrIT. When your VM is provisioned you should receive a message from EngrIT in the [secure messaging portal](https://my.engr.illinois.edu/smd).
+For all registered students in the course, you will receive a VM in the CS Department’s VM Farm provisioned by EngrIT. When your VM is provisioned you should receive an email from the course staff or Professor Angrave with information about your VM. If you registered late, please email the CS 241 Admin (you can find the email on our [staff page]({% link _pages/staff.html %})).
 
-Once you have received your VM, you can connect to your VM via SSH. The VM number will be in the message from EngrIT. 
+Once you have received your VM, you can connect to your VM via SSH. The VM number will be included in the email you received.
 
 On Linux / Mac, you can do something like
 ```console
@@ -26,3 +26,9 @@ Note that if you are not connected to on-campus internet, you will need to use a
 This is your VM! Install whatever you want on it (given that it is school appropriate). That is, you can install `vim` or `emacs`. If you've ever wanted to become terminal-savvy, this is definitely the course to do it.
 
 If anything is unclear, either post on the course forums or ask your TAs/CAs/fellow students! **Be careful about messing up your VM.** If your VM ever gets into an unusable state, please make a private post in the course forums **with your VM number**, and we will try to resolve it.
+
+## Provisioning a local VM using Vagrant
+
+If you are taking the course remotely and have slow internet when connected to the Campus VPN, you can set up a VM locally (on your own computer) using Vagrant. [This page]({% link _tutorials/development_vagrant.md %}) has instructions on how to do that.
+
+**Note: Your EngrIT-provisioned VM is still the authoritive place for final testing. Your local Vagrant VM is just a way to help remote students with development.**

--- a/_tutorials/development_vagrant.md
+++ b/_tutorials/development_vagrant.md
@@ -1,19 +1,14 @@
 ---
 layout: doc
-title: "Development Guide"
+title: "Vagrant Setup Guide"
 learning_objectives:
-  - Using the tools needed for CS 241
+  - Setting up a local VM using Vagrant
 ---
 
-## Development in CS 241 for Spring 2021
-In this course, we use Virtual Machines (VMs) for all our developmment. We will not support development in any other enviornment (e.g. EWS).
+## Setup Instructions
+We are [Vagrant](https://www.vagrantup.com/) to provision VMs. Vagrant allows us to provide a consistent VM environment, similar to your EngrIT-provisioned VM and the environment in which assignments will be graded.
 
-For most students in the course, you will need to setup a VM for development on your personal computer. A small number of students may receive VMs from the CS Department's VM Farm if their personal computer isn't powerful enough. Below are tutorials on how to setup / access your VMs.
-
-## Local (Personal Computer) VM
-We are using [Vagrant](https://www.vagrantup.com/) to provision VMs. Vagrant allows us to provide a consistent VM environment, similar to the environment in which assignments will be graded.
-
-Here are the steps to setup your personal VM.
+Here are the steps to provision a VM on your own laptop using Vagrant:
 
 1. You will first need to install Vagrant. You can do this by following the instructions at [this page](https://www.vagrantup.com/docs/installation).
 
@@ -21,7 +16,7 @@ Here are the steps to setup your personal VM.
 
 3. Next, you will need to download a Vagrantfile. The Vagrantfile sets the enviornment for your VM, so please do not modify it. The libraries configured are the exact same versions as the ones that will be used when grading. We have 2 different versions depending on the number of cores your computer has. If your computer has 2 cores, download [this version](../resources/development/Vagrantfile_2_cores). If your computer has 4 or more cores, download [this version](../resources/development/Vagrantfile_4_cores).
 
-4. Next, make a directory called `cs241-vm`. Move the downloaded file from step (3) into this folder, and rename the downloaded file to `Vagrantfile`.
+4. Next, make a directory called `cs241-vm`. Move the downloaded file from step (3) into this folder, and **rename the downloaded file to `Vagrantfile`**.
 
 Now, everything needed for your VM should be installed. Here are some commands that you will need to use to connect to your personal VM. All these commands should be run in the `cs241-vm` directory (i.e. the directory that contains the Vagrantfile).
 1. `vagrant up` - This command turns on and configures the VM according to the Vagrantfile.
@@ -31,18 +26,3 @@ Now, everything needed for your VM should be installed. Here are some commands t
 Here's the complete list of commands: [https://www.vagrantup.com/docs/cli](https://www.vagrantup.com/docs/cli).
 
 If you want to use a VScode SSH plugin to edit the files on Vagrant VM, you can configure the plugin to connect to localhost port 2222 with user name "student" (e.g. `ssh student@localhost -p 2222`). No password is needed if you use the correct ssh config files.
-
-
-## Remote (CS Cloud) VM
-If you are receiving a VM from the CS VM Farm, you will not need to do any setup. When your VM is provisioned you should receive a message from EngrIT in the [secure messaging portal](https://my.engr.illinois.edu/smd).
-
-Once you have received your VM, you can connect to your VM via SSH. The VM number will be in the message from EngrIT. 
-
-On Linux / Mac, you can do something like
-```console
-$ ssh <NETID>@{{site.data.constants.semester }}-{{ site.data.constants.department_code }}{{ site.data.constants.course_number }}-<NUM>.cs.illinois.edu
-```
-
-On Windows, you can use an SSH client like [PuTTY](https://www.putty.org/).
-
-Note that if you are not connected to on-campus internet, you will need to use a Virtual Private Network (VPN) to connect to your VM. Instructions on downloading and using the UIUC VPN can be found [here](https://answers.uillinois.edu/illinois/98773). An alternative to using the UIUC VPN is to SSH twice. You can first into your EWS account and then into your personal VM. Just remember that this causes potentially double the network lag!


### PR DESCRIPTION
1. Updates the Vagrantfiles to Ubuntu 18 (and updates corresponding library versions to match the ones in the EngrIT VMs):

![Screenshot from 2021-08-26 15-13-56](https://user-images.githubusercontent.com/16738329/131029756-8a91caec-c737-48fe-a617-be01d54e7b77.png)

2. Updates info on webpage with new info:
- Email sent from course staff / Angrave instead of EngrIT
- Email CS 241 Admin instead of EngrIT for late adds
- Add short blob in development guide about setting up local VM using Vagrant and links to the Vagrant page.