### PR TITLE
Fix link to Welcome letter in schedule

### DIFF
--- a/_data/schedule.yaml
+++ b/_data/schedule.yaml
@@ -18,7 +18,7 @@ classes:
   - title: "Welcome to System Programming"
     summary: "1. HW0 using my Linux-In-The-Browser minicourse (Zoom link will be posted on Ed)"
     review_chapter: 3
-    resources: "See <a href = 'https://github.com/angrave/cs341-fa22/blob/main/Welcome.md'>Welcome</a>"
+    resources: "See <a href = 'https://github.com/angrave/CS341-Lectures-FA22/blob/main/Welcome.md'>Welcome</a>"
     color: "#F44336"
     number: 1
   - title: "How to crash in C"

--- a/_pages/links.md
+++ b/_pages/links.md
@@ -8,6 +8,6 @@ title: Useful Links
 Lecture videos: [https://classtranscribe.illinois.edu/](https://classtranscribe.illinois.edu/)  
 (For any issues related to Class Transcribe, you'd probably get a faster response by emailing [classtranscribe@illinois.edu](mailto:classtranscribe@illinois.edu))
 
-Lecture demo code and handouts: https://github.com/angrave/cs341-fa22
+Lecture demo code and handouts: https://github.com/angrave/CS341-Lectures-FA22
 
 HW 0 Mini Lectures & in-browser VM: [http://cs-education.github.io/sys/#/lessons](http://cs-education.github.io/sys/#/lessons)


### PR DESCRIPTION
Quick fix to swap a broken link.
It doesn't seem like `https://github.com/angrave/cs341-fa22` is even a repository so there may be other broken links if more depend on this URL. It seems like `https://github.com/angrave/CS341-Lectures-FA22` should be the correct base link.