### PR TITLE
Rakefile Fix

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,18 +15,15 @@ jobs:
     - name: Setup ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 2.6
         bundler-cache: true
 
     - name: Install dependencies
       run: |
         sudo apt install hunspell libhunspell-dev hunspell-en-us
-        gem install rake -v '0.9.6'
 
     - name: Build site
       run: |
-        gem install nokogiri -v 1.13.10
-        bundle update rake
         bundle exec rake
         bundle exec rake spell_check
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,6 +25,7 @@ jobs:
 
     - name: Build site
       run: |
+        bundle update rake
         bundle exec rake
         bundle exec rake spell_check
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,7 @@ name: Website Deploy
 on:
   push:
     branches:
-      - xinyi/workflow_fix
+      - develop
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Build site
       run: |
-        gem update --system 3.2.3
+        bundle install nokogiri
         bundle update rake
         bundle exec rake
         bundle exec rake spell_check

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,7 @@ name: Website Deploy
 on:
   push:
     branches:
-      - develop
+      - xinyi/workflow_fix
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,15 +27,15 @@ jobs:
         bundle exec rake
         bundle exec rake spell_check
 
-    - name: Deploy site
-      run: |
-        # Needed to add the --no-tty --batch --yes flags to get gpg to work in Github Actions
-        # Based on this: https://discuss.circleci.com/t/error-sending-to-agent-inappropriate-ioctl-for-device/17465/3
-        gpg --no-tty --batch --yes --passphrase ${{ secrets.GPG_PASSPHRASE }} --output /tmp/dual_deploy_key --decrypt dual_deploy_key.enc
-        eval "$(ssh-agent -s)"
-        chmod 600 /tmp/dual_deploy_key
+    # - name: Deploy site
+    #   run: |
+    #     # Needed to add the --no-tty --batch --yes flags to get gpg to work in Github Actions
+    #     # Based on this: https://discuss.circleci.com/t/error-sending-to-agent-inappropriate-ioctl-for-device/17465/3
+    #     gpg --no-tty --batch --yes --passphrase ${{ secrets.GPG_PASSPHRASE }} --output /tmp/dual_deploy_key --decrypt dual_deploy_key.enc
+    #     eval "$(ssh-agent -s)"
+    #     chmod 600 /tmp/dual_deploy_key
 
-        # Email from: # https://github.community/t/github-actions-bot-email-address/17204/6
-        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git config --global user.name "Github Actions Bot"
-        bash _scripts/deploy.sh
+    #     # Email from: # https://github.community/t/github-actions-bot-email-address/17204/6
+    #     git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+    #     git config --global user.name "Github Actions Bot"
+    #     bash _scripts/deploy.sh

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,6 +20,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        gem install rake -v '0.9.6'
         sudo apt install hunspell libhunspell-dev hunspell-en-us
 
     - name: Build site

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,15 +27,15 @@ jobs:
         bundle exec rake
         bundle exec rake spell_check
 
-    # - name: Deploy site
-    #   run: |
-    #     # Needed to add the --no-tty --batch --yes flags to get gpg to work in Github Actions
-    #     # Based on this: https://discuss.circleci.com/t/error-sending-to-agent-inappropriate-ioctl-for-device/17465/3
-    #     gpg --no-tty --batch --yes --passphrase ${{ secrets.GPG_PASSPHRASE }} --output /tmp/dual_deploy_key --decrypt dual_deploy_key.enc
-    #     eval "$(ssh-agent -s)"
-    #     chmod 600 /tmp/dual_deploy_key
+    - name: Deploy site
+      run: |
+        # Needed to add the --no-tty --batch --yes flags to get gpg to work in Github Actions
+        # Based on this: https://discuss.circleci.com/t/error-sending-to-agent-inappropriate-ioctl-for-device/17465/3
+        gpg --no-tty --batch --yes --passphrase ${{ secrets.GPG_PASSPHRASE }} --output /tmp/dual_deploy_key --decrypt dual_deploy_key.enc
+        eval "$(ssh-agent -s)"
+        chmod 600 /tmp/dual_deploy_key
 
-    #     # Email from: # https://github.community/t/github-actions-bot-email-address/17204/6
-    #     git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-    #     git config --global user.name "Github Actions Bot"
-    #     bash _scripts/deploy.sh
+        # Email from: # https://github.community/t/github-actions-bot-email-address/17204/6
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "Github Actions Bot"
+        bash _scripts/deploy.sh

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,6 +25,8 @@ jobs:
 
     - name: Build site
       run: |
+        bundle show rake
+        gem list rake
         bundle update rake
         bundle exec rake
         bundle exec rake spell_check

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,8 +20,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        gem install rake -v '0.9.6'
         sudo apt install hunspell libhunspell-dev hunspell-en-us
+        gem install rake -v '0.9.6'
 
     - name: Build site
       run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
+        ruby-version: 2.7
         bundler-cache: true
 
     - name: Install dependencies
@@ -25,7 +25,7 @@ jobs:
 
     - name: Build site
       run: |
-        gem install nokogiri
+        gem install nokogiri -v 1.13.10
         bundle update rake
         bundle exec rake
         bundle exec rake spell_check

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Build site
       run: |
-        bundle install nokogiri
+        gem install nokogiri
         bundle update rake
         bundle exec rake
         bundle exec rake spell_check

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,8 +25,7 @@ jobs:
 
     - name: Build site
       run: |
-        bundle show rake
-        gem list rake
+        gem update --system 3.2.3
         bundle update rake
         bundle exec rake
         bundle exec rake spell_check

--- a/Rakefile
+++ b/Rakefile
@@ -104,7 +104,7 @@ namespace :pre_build do
     output = {}
     urls.each do |url|
       puts url
-      page = Nokogiri::HTML(open(url),'User-Agent' => 'firefox')
+      page = Nokogiri::HTML(open(url),OpenSSL::SSL::VERIFY_NONE,'User-Agent' => 'firefox')
       page.css('dt a').each do |link|
         output[link.inner_html] = url + link['href']
       end

--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,7 @@ require 'yaml'
 require 'fileutils'
 require 'nokogiri'
 require 'json'
+require 'openssl'
 
 is_travis = ENV['TRAVIS'] == 'true'
 main_json_file = '_data/man.json'
@@ -104,7 +105,7 @@ namespace :pre_build do
     output = {}
     urls.each do |url|
       puts url
-      page = Nokogiri::HTML(open(url,'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/600.1.17 (KHTML, like Gecko) Version/8.0 Safari/600.1.17'))
+      page = Nokogiri::HTML(open(url,ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE, 'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/600.1.17 (KHTML, like Gecko) Version/8.0 Safari/600.1.17'))
       page.css('dt a').each do |link|
         output[link.inner_html] = url + link['href']
       end

--- a/Rakefile
+++ b/Rakefile
@@ -82,7 +82,7 @@ namespace :pre_build do
   desc 'Houses all pre build tasks'
 
   sections = [1, 2, 3, 4]
-  desc 'https://linux.die.net/man/1/ throws 403'
+  desc 'https://linux.die.net/man/ throws 403; see their robots.txt for more info'
   base_url = 'https://man7.org/linux/man-pages/'
   cache_time = 30 # days
 
@@ -109,7 +109,6 @@ namespace :pre_build do
       page.css('a').each do |link|
         func_name = link.inner_html.match(/^(\w+)/)[1]
         if !output.key?(func_name)
-          puts "there" + func_name
           output[func_name] = base_url + link['href']
         end
       end

--- a/Rakefile
+++ b/Rakefile
@@ -103,7 +103,7 @@ namespace :pre_build do
     end
     output = {}
     urls.each do |url|
-      page = Nokogiri::HTML(open(url))
+      page = Nokogiri::HTML(open(url),'User-Agent' => 'firefox')
       page.css('dt a').each do |link|
         output[link.inner_html] = url + link['href']
       end

--- a/Rakefile
+++ b/Rakefile
@@ -109,6 +109,8 @@ namespace :pre_build do
       page = Nokogiri::HTML(open(url,ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE, 'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/600.1.17 (KHTML, like Gecko) Version/8.0 Safari/600.1.17'))
       page.css('dt a').each do |link|
         output[link.inner_html] = base_url + link['href']
+        puts 'here' + link.inner_html
+        puts output[link.inner_html]
       end
     end
 

--- a/Rakefile
+++ b/Rakefile
@@ -82,7 +82,8 @@ namespace :pre_build do
   desc 'Houses all pre build tasks'
 
   sections = [1, 2, 3, 4]
-  base_uri = 'https://linux.die.net/man/'
+  desc 'https://linux.die.net/man/1/ throws 403'
+  base_uri = 'https://man7.org/linux/man-pages/man'
   cache_time = 30 # days
 
   task :gen_man, [:file] do |_t, args|
@@ -105,7 +106,7 @@ namespace :pre_build do
     output = {}
     urls.each do |url|
       puts url
-      page = Nokogiri::HTML(open('https://man7.org/linux/man-pages/man2/',ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE, 'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/600.1.17 (KHTML, like Gecko) Version/8.0 Safari/600.1.17'))
+      page = Nokogiri::HTML(open(url,ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE, 'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/600.1.17 (KHTML, like Gecko) Version/8.0 Safari/600.1.17'))
       page.css('dt a').each do |link|
         output[link.inner_html] = url + link['href']
       end

--- a/Rakefile
+++ b/Rakefile
@@ -104,7 +104,7 @@ namespace :pre_build do
     output = {}
     urls.each do |url|
       puts url
-      page = Nokogiri::HTML(open(url,ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE,'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/600.1.17 (KHTML, like Gecko) Version/8.0 Safari/600.1.17'))
+      page = Nokogiri::HTML(open(url,'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/600.1.17 (KHTML, like Gecko) Version/8.0 Safari/600.1.17'))
       page.css('dt a').each do |link|
         output[link.inner_html] = url + link['href']
       end

--- a/Rakefile
+++ b/Rakefile
@@ -109,6 +109,8 @@ namespace :pre_build do
       page = Nokogiri::HTML(open(url,ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE, 'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/600.1.17 (KHTML, like Gecko) Version/8.0 Safari/600.1.17'))
       page.css('dt a').each do |link|
         output[link.inner_html] = url + link['href']
+        puts link.inner_html
+        puts output[link.inner_html
       end
     end
 

--- a/Rakefile
+++ b/Rakefile
@@ -104,7 +104,7 @@ namespace :pre_build do
     output = {}
     urls.each do |url|
       puts url
-      page = Nokogiri::HTML(open(url),ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE,'User-Agent' => 'firefox')
+      page = Nokogiri::HTML(open(url,ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE,'User-Agent' => 'firefox'))
       page.css('dt a').each do |link|
         output[link.inner_html] = url + link['href']
       end

--- a/Rakefile
+++ b/Rakefile
@@ -107,8 +107,7 @@ namespace :pre_build do
     urls.each do |url|
       puts url
       page = Nokogiri::HTML(open(url,ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE, 'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/600.1.17 (KHTML, like Gecko) Version/8.0 Safari/600.1.17'))
-      puts "here" + page
-      page.css('dt a').each do |link|
+      page.css('a').each do |link|
         output[link.inner_html] = base_url + link['href']
         puts 'here' + link.inner_html
         puts output[link.inner_html]

--- a/Rakefile
+++ b/Rakefile
@@ -110,7 +110,7 @@ namespace :pre_build do
       page.css('dt a').each do |link|
         output[link.inner_html] = url + link['href']
         puts link.inner_html
-        puts output[link.inner_html
+        puts output[link.inner_html]
       end
     end
 

--- a/Rakefile
+++ b/Rakefile
@@ -104,7 +104,7 @@ namespace :pre_build do
     output = {}
     urls.each do |url|
       puts url
-      page = Nokogiri::HTML(open(url),OpenSSL::SSL::VERIFY_NONE,'User-Agent' => 'firefox')
+      page = Nokogiri::HTML(open(url),ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE,'User-Agent' => 'firefox')
       page.css('dt a').each do |link|
         output[link.inner_html] = url + link['href']
       end

--- a/Rakefile
+++ b/Rakefile
@@ -83,7 +83,7 @@ namespace :pre_build do
 
   sections = [1, 2, 3, 4]
   desc 'https://linux.die.net/man/1/ throws 403'
-  base_uri = 'https://man7.org/linux/man-pages/man'
+  base_url = 'https://man7.org/linux/man-pages/'
   cache_time = 30 # days
 
   task :gen_man, [:file] do |_t, args|
@@ -101,16 +101,14 @@ namespace :pre_build do
     puts 'Updating file'
 
     urls = sections.map do |e|
-      base_uri + e.to_s + '/'
+      base_url + 'dir_section_' + e.to_s + '.html'
     end
     output = {}
     urls.each do |url|
       puts url
       page = Nokogiri::HTML(open(url,ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE, 'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/600.1.17 (KHTML, like Gecko) Version/8.0 Safari/600.1.17'))
       page.css('dt a').each do |link|
-        output[link.inner_html] = url + link['href']
-        puts link.inner_html
-        puts output[link.inner_html]
+        output[link.inner_html] = base_url + link['href']
       end
     end
 

--- a/Rakefile
+++ b/Rakefile
@@ -107,7 +107,10 @@ namespace :pre_build do
     urls.each do |url|
       page = Nokogiri::HTML(open(url,ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE, 'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/600.1.17 (KHTML, like Gecko) Version/8.0 Safari/600.1.17'))
       page.css('a').each do |link|
-        output[link.inner_html] = base_url + link['href']
+        func_name = link.inner_html.match(/^(\w+)/)[1]
+        if !output.key?(func_name)
+          output[func_name] = base_url + link['href']
+        end
       end
     end
 

--- a/Rakefile
+++ b/Rakefile
@@ -109,6 +109,7 @@ namespace :pre_build do
       page.css('a').each do |link|
         func_name = link.inner_html.match(/^(\w+)/)[1]
         if !output.key?(func_name)
+          puts "there" + func_name
           output[func_name] = base_url + link['href']
         end
       end

--- a/Rakefile
+++ b/Rakefile
@@ -104,7 +104,7 @@ namespace :pre_build do
     output = {}
     urls.each do |url|
       puts url
-      page = Nokogiri::HTML(open(url,ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE,'User-Agent' => 'firefox'))
+      page = Nokogiri::HTML(open(url,ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE,'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/600.1.17 (KHTML, like Gecko) Version/8.0 Safari/600.1.17'))
       page.css('dt a').each do |link|
         output[link.inner_html] = url + link['href']
       end

--- a/Rakefile
+++ b/Rakefile
@@ -105,7 +105,7 @@ namespace :pre_build do
     output = {}
     urls.each do |url|
       puts url
-      page = Nokogiri::HTML(open(url,ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE, 'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/600.1.17 (KHTML, like Gecko) Version/8.0 Safari/600.1.17'))
+      page = Nokogiri::HTML(open('https://man7.org/linux/man-pages/man2/',ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE, 'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/600.1.17 (KHTML, like Gecko) Version/8.0 Safari/600.1.17'))
       page.css('dt a').each do |link|
         output[link.inner_html] = url + link['href']
       end

--- a/Rakefile
+++ b/Rakefile
@@ -105,12 +105,9 @@ namespace :pre_build do
     end
     output = {}
     urls.each do |url|
-      puts url
       page = Nokogiri::HTML(open(url,ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE, 'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/600.1.17 (KHTML, like Gecko) Version/8.0 Safari/600.1.17'))
       page.css('a').each do |link|
         output[link.inner_html] = base_url + link['href']
-        puts 'here' + link.inner_html
-        puts output[link.inner_html]
       end
     end
 

--- a/Rakefile
+++ b/Rakefile
@@ -107,6 +107,7 @@ namespace :pre_build do
     urls.each do |url|
       puts url
       page = Nokogiri::HTML(open(url,ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE, 'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/600.1.17 (KHTML, like Gecko) Version/8.0 Safari/600.1.17'))
+      puts "here" + page
       page.css('dt a').each do |link|
         output[link.inner_html] = base_url + link['href']
         puts 'here' + link.inner_html

--- a/Rakefile
+++ b/Rakefile
@@ -103,6 +103,7 @@ namespace :pre_build do
     end
     output = {}
     urls.each do |url|
+      puts url
       page = Nokogiri::HTML(open(url),'User-Agent' => 'firefox')
       page.css('dt a').each do |link|
         output[link.inner_html] = url + link['href']


### PR DESCRIPTION
We noticed that the workflow failed with `OpenURI::HTTPError: 403 Forbidden` error. This is caused by the `robots.txt` in `https://linux.die.net/`. We switched to `https://man7.org/linux/man-pages/`. Further changes are to make the link work for the functions in our assignment document. e.g. `malloc` in [`mini_memcheck`](https://cs341.cs.illinois.edu/assignments/mini_memcheck.html)