### PR TITLE
lockpicking lab: add --no-rebase flag

### DIFF
--- a/_docs/lockpicking_lab.md
+++ b/_docs/lockpicking_lab.md
@@ -97,7 +97,7 @@ You've probably noticed the repository is empty! In order to grab the latest ver
 
 ```console
 git remote add release https://github.com/illinois-cs-coursework/{{site.data.constants.semester }}_{{ site.data.constants.department_code }}{{site.data.constants.course_number}}_.release.git
-git pull release main --allow-unrelated-histories
+git pull release main --allow-unrelated-histories --no-rebase
 git push origin main
 ```
 


### PR DESCRIPTION
we get several student questions on Edstem each year about git pull not working (due to improper flag usage). let's preemptively address these questions