### PR TITLE
Update heap checker doc with note to not strictly follow example

### DIFF
--- a/_docs/malloc.md
+++ b/_docs/malloc.md
@@ -176,6 +176,8 @@ Now, you can place calls to heap_check at the beginning and end of every functio
 
 To reiterate, **course staff will ask you to demonstrate your heap checker if you are asking for help in office hours!**
 
+**!! Important Note**: In the above heap checker example, the `metadata` struct was implemented with its `next` pointer pointing to the next _physically adjacent_ block. This does NOT mean that you must implement your `metdata` struct or `next` pointer in this way - this was a simple example we created to demonstrate how you may use a heap checker. You are allowed (and encouraged) to design and implement a different implementation of the `metadata` struct to improve performance.
+
 ## Testing Your Code
 
 In order to run your solution on the testers, run `./mcontest` with the tester you want. You __must__ do this, or your code will be run with the glibc implementation!


### PR DESCRIPTION
The heap checker documentation in malloc previously implied to students that they must use a `next` pointer in the `metadata` struct that points to the next _physically_ adjacent block. Students thought that they have to implement their metadata struct in this manner, which made it harder for them to pass part 2 test cases. 

I added a note at the end of the heap checker documentation simply stating that they do not have to conform to the  implementation in the example, and that they are encouraged to try new implementations that they feel will have improved performance. I kept it vague so that it doesn't imply that they must follow any certain implementation and so that they are free to think and design something on their own.