### PR TITLE
Upgrade Ruby to 3.3

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
+        ruby-version: 3.3
         bundler-cache: true
 
     - name: Install dependencies

--- a/Rakefile
+++ b/Rakefile
@@ -105,7 +105,7 @@ namespace :pre_build do
     end
     output = {}
     urls.each do |url|
-      page = Nokogiri::HTML(open(url,ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE, 'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/600.1.17 (KHTML, like Gecko) Version/8.0 Safari/600.1.17'))
+      page = Nokogiri::HTML(URI.open(url,ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE, 'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/600.1.17 (KHTML, like Gecko) Version/8.0 Safari/600.1.17'))
       page.css('a').each do |link|
         func_name = link.inner_html.match(/^(\w+)/)[1]
         output[func_name] = base_url + link['href']


### PR DESCRIPTION
Why are we still using Ruby 2.6?

Under no circumstances is it a good idea to hijack and overload system calls, so Ruby 3 deprecated the use of the overloaded `Kernel.open` to open URIs. Now you need to call `URI.open` - much better.