### PR TITLE
Update Gemfile.lock based on Gemfile updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.1.1)
+    activesupport (8.0.0)
       base64
+      benchmark (>= 0.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
@@ -12,10 +13,13 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.2.0)
+    benchmark (0.4.0)
     bigdecimal (3.1.8)
+    cgi (0.4.1)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -31,10 +35,12 @@ GEM
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
+    erb (4.0.4)
+      cgi (>= 0.3.3)
     ethon (0.16.0)
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
-    execjs (2.9.1)
+    execjs (2.10.0)
     exifr (1.4.0)
     faraday (2.12.0)
       faraday-net_http (>= 2.0, < 3.4)
@@ -228,7 +234,7 @@ GEM
       gemoji (>= 3, < 5)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    json (2.7.2)
+    json (2.8.1)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -244,7 +250,7 @@ GEM
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.25.1)
-    net-http (0.4.1)
+    net-http (0.5.0)
       uri
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
@@ -264,7 +270,7 @@ GEM
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     redcarpet (3.6.0)
-    rexml (3.3.8)
+    rexml (3.3.9)
     rouge (3.30.0)
     rubyzip (2.3.2)
     safe_yaml (1.0.5)
@@ -278,7 +284,7 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    securerandom (0.3.1)
+    securerandom (0.3.2)
     simpleidn (0.2.3)
     sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
@@ -290,13 +296,14 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
-    uri (0.13.1)
-    webrick (1.8.2)
+    uri (1.0.1)
+    webrick (1.9.0)
 
 PLATFORMS
   x86_64-linux-gnu
 
 DEPENDENCIES
+  erb
   ffi-hunspell
   github-pages
   htmlentities


### PR DESCRIPTION
Site update #335  added a broken Gemfile.lock, reran `bundle install` and got an update here.