### PR TITLE
updating gen AI in syllabus

### DIFF
--- a/_pages/syllabus.md
+++ b/_pages/syllabus.md
@@ -158,8 +158,9 @@ Lab attendance credit will *not* be given unless you are physically present in l
 
 You may use Large Language AI  Models (e.g. Github Copilot, ChatGPT, and other models) in this class with the following conditions-
 
-* You must document their use in your code. Clearly describe which parts of your submitted code were generated automatically.
+* You must document their use in your code. Clearly describe which parts of your submitted code were developed with the help of generative AI.
 * Document when you used an AI model as part of your development process and how well it worked. Specifically, in your code comments describe if you used an AI model to assist in your initial design, initial implementation, developing test code, debugging code or other software development process.
+* You may NOT use generative AI to complete (large portions of) assignments for you. Please see the Academic Integrity section below.
 
 ## Academic Integrity
 

--- a/_pages/syllabus.md
+++ b/_pages/syllabus.md
@@ -160,7 +160,7 @@ You may use Large Language AI  Models (e.g. Github Copilot, ChatGPT, and other m
 
 * You must document their use in your code. Clearly describe which parts of your submitted code were developed with the help of generative AI.
 * Document when you used an AI model as part of your development process and how well it worked. Specifically, in your code comments describe if you used an AI model to assist in your initial design, initial implementation, developing test code, debugging code or other software development process.
-* You may NOT use generative AI to complete (large portions of) assignments for you. Please see the Academic Integrity section below.
+* Unless explicitly allowed by the assignment or exam, you may NOT use generative AI to complete (large portions of) assignments for you. Please see the Academic Integrity section below.
 
 ## Academic Integrity
 


### PR DESCRIPTION
Changed the sentence that generative AI may be used to describe that how its used must be documented and removed any reference to automatically generating code.
Added one sentence giving an explicit reminder and forward pointer to the academic integrity section.