### PR TITLE
fix main page grading policy to match syllabus

### DIFF
--- a/_pages/index.html
+++ b/_pages/index.html
@@ -162,14 +162,17 @@ title: Home
                         Grading Policy (subject to minor changes)
                     </h2>
                     <p>
-                        <strong>Machine Problems: </strong>45% (weekly)
+                        <strong>Machine Problems: </strong>45% (weekly).
                     </p>
                     <p>
-                        <strong>Labs: </strong>17% (weekly, lowest lab dropped)
+                        <strong>Labs: </strong>17% (weekly, lowest lab dropped).
                     </p>
                     
                     <p>
                       <strong>Quizzes: </strong> 15% (7 quizzes, multiple re-takes, no drops). At <a href='https://www.prairielearn.org/'>PrairieLearn</a>; Available until Reading Day.
+                    </p>
+                    <p>
+                        <strong> Midterm Exam </strong> 9%.
                     </p>
                     <p>
                         <strong>Final Exam: </strong>23% ; however upto 3% can be pre-credited based on physical lab attendance i.e. the fractional contribution of the final exam can be reduced.


### PR DESCRIPTION
Updating the grading policy on the main course page to match the syllabus.